### PR TITLE
fix: make font work in storybook

### DIFF
--- a/infrastructure/eid-wallet/.storybook/main.ts
+++ b/infrastructure/eid-wallet/.storybook/main.ts
@@ -22,5 +22,6 @@ const config: StorybookConfig = {
     name: getAbsolutePath("@storybook/sveltekit"),
     options: {},
   },
+  staticDirs: ["../static"],
 };
 export default config;


### PR DESCRIPTION
# Description of change
Fixes Archivo not working in storybook, for typography parity in ui and storybook
 
## Issue Number
Closes #53 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested
Storybook/Manual 

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code
