### PR TITLE
feat: charter signature verification error display

### DIFF
--- a/platforms/group-charter-manager-api/src/controllers/CharterSigningController.ts
+++ b/platforms/group-charter-manager-api/src/controllers/CharterSigningController.ts
@@ -94,6 +94,10 @@ export class CharterSigningController {
                         res.write(`data: ${JSON.stringify({ type: "expired" })}\n\n`);
                         clearInterval(interval);
                         res.end();
+                    } else if (session.status === "security_violation") {
+                        res.write(`data: ${JSON.stringify({ type: "security_violation" })}\n\n`);
+                        clearInterval(interval);
+                        res.end();
                     }
                 } else {
                     res.write(`data: ${JSON.stringify({ type: "error", message: "Session not found" })}\n\n`);

--- a/platforms/group-charter-manager/src/components/charter-signing-interface.tsx
+++ b/platforms/group-charter-manager/src/components/charter-signing-interface.tsx
@@ -22,7 +22,7 @@ interface CharterSigningInterfaceProps {
 export function CharterSigningInterface({ groupId, charterData, onSigningComplete, onCancel, onSigningStatusUpdate }: CharterSigningInterfaceProps) {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [qrData, setQrData] = useState<string | null>(null);
-  const [status, setStatus] = useState<"pending" | "connecting" | "signed" | "expired" | "error">("pending");
+  const [status, setStatus] = useState<"pending" | "connecting" | "signed" | "expired" | "error" | "security_violation">("pending");
   const [timeRemaining, setTimeRemaining] = useState<number>(900); // 15 minutes in seconds
   const [eventSource, setEventSource] = useState<EventSource | null>(null);
   const { toast } = useToast();
@@ -106,6 +106,13 @@ export function CharterSigningInterface({ groupId, charterData, onSigningComplet
           toast({
             title: "Session Expired",
             description: "The signing session has expired. Please try again.",
+            variant: "destructive",
+          });
+        } else if (data.type === "security_violation") {
+          setStatus("security_violation");
+          toast({
+            title: "eName Verification Failed",
+            description: "eName verification failed. Please check your eID.",
             variant: "destructive",
           });
         } else {
@@ -249,6 +256,31 @@ export function CharterSigningInterface({ groupId, charterData, onSigningComplet
               Your charter has been securely signed. 
             </p>
           </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (status === "security_violation") {
+    return (
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader className="text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-500" />
+            eName verification failed
+          </CardTitle>
+          <CardDescription>
+            eName verification failed
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          <div className="bg-red-50 p-4 rounded-lg">
+            <p className="text-red-800 text-sm">
+              eName Mismatch: It appears that you are trying to sign with the wrong eName. 
+              Please make sure you are signing with the right eID linked to this account.
+            </p>
+          </div>
+          <Button onClick={onCancel} variant="secondary">Close</Button>
         </CardContent>
       </Card>
     );


### PR DESCRIPTION
# Description of change

## Issue Number

## Type of change

- Breaking (any change that would cause existing functionality to not work as expected)
- New (a change which implements a new feature)
- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)
- Docs (changes to the documentation)
- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

## Change checklist

- [ ] I have ensured that the CI Checks pass locally
- [ ] I have removed any unnecessary logic
- [ ] My code is well documented
- [ ] I have signed my commits
- [ ] My code follows the pattern of the application
- [ ] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit handling for eName/eID verification failures during charter signing, showing a clear error screen with guidance.
  * Displays a destructive toast notification when verification fails, prompting users to check their eID details.
  * Improves session termination behavior on verification failure, preventing the flow from continuing and allowing users to close and retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->