### PR TITLE
fix: dual chat init dreamsync

### DIFF
--- a/platforms/dreamsync-api/src/controllers/WebhookController.ts
+++ b/platforms/dreamsync-api/src/controllers/WebhookController.ts
@@ -164,6 +164,13 @@ export class WebhookController {
             return res.status(200).send("Skipped Match ID group");
         }
 
+        // Check if this is a DM with DM ID in description (already processed)
+        if (local.data.description && typeof local.data.description === 'string' && local.data.description.startsWith('DM ID:')) {
+            console.log("⏭️ Skipping DM creation - this DM has DM ID in description (already processed)");
+            await this.webhookProcessingService.markWebhookCompleted(req.body);
+            return res.status(200).send("Skipped DM ID group");
+        }
+
                 let participants: User[] = [];
                 if (
                     local.data.participants &&

--- a/platforms/dreamsync-api/src/services/ConsentService.ts
+++ b/platforms/dreamsync-api/src/services/ConsentService.ts
@@ -1379,14 +1379,14 @@ DreamSync Team
             // Create new mutual chat
             console.log(`🔧 ConsentService: Creating mutual chat with:`);
             console.log(`   - Name: DreamSync Chat with ${userId}`);
-            console.log(`   - Description: Private chat with DreamSync platform`);
+            console.log(`   - Description: DM ID: ${userId}::${dreamsyncUser.id}`);
             console.log(`   - Owner: ${dreamsyncUser.id}`);
             console.log(`   - Members: [${dreamsyncUser.id}, ${userId}]`);
             console.log(`   - Private: true`);
             
             const mutualChat = await this.groupService.createGroup(
                 `DreamSync Chat with ${userId}`,
-                "Private chat with DreamSync platform",
+                `DM ID: ${userId}::${dreamsyncUser.id}`,
                 dreamsyncUser.id,
                 [dreamsyncUser.id],
                 [dreamsyncUser.id, userId],

--- a/platforms/dreamsync-api/src/services/MatchNotificationService.ts
+++ b/platforms/dreamsync-api/src/services/MatchNotificationService.ts
@@ -82,8 +82,8 @@ export class MatchNotificationService {
             console.log(`🆕 No existing mutual chat found, creating new one...`);
 
             // Create a new mutual chat
-            const chatName = `DreamSync Chat`;
-            const chatDescription = `Private chat between DreamSync and user for match notifications`;
+            const chatName = `DreamSync Chat with ${targetUserId}`;
+            const chatDescription = `DM ID: ${targetUserId}::${dreamsyncUser.id}`;
             
             console.log(`🔧 Creating mutual chat with:`);
             console.log(`   - Name: ${chatName}`);

--- a/platforms/dreamsync-api/src/web3adapter/watchers/subscriber.ts
+++ b/platforms/dreamsync-api/src/web3adapter/watchers/subscriber.ts
@@ -414,6 +414,12 @@ export class PostgresSubscriber implements EntitySubscriberInterface {
                 return;
             }
 
+            // Skip DMs with DM ID in description (already processed)
+            if (data.description && typeof data.description === 'string' && data.description.startsWith('DM ID:')) {
+                console.log(`🔍 Skipping DM webhook - has DM ID in description: ${data.description}`);
+                return;
+            }
+
             let globalId = await this.adapter.mappingDb.getGlobalId(data.id);
             globalId = globalId ?? "";
 


### PR DESCRIPTION
# Description of change

## Issue Number

## Type of change

- Breaking (any change that would cause existing functionality to not work as expected)
- New (a change which implements a new feature)
- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)
- Docs (changes to the documentation)
- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

## Change checklist

- [ ] I have ensured that the CI Checks pass locally
- [ ] I have removed any unnecessary logic
- [ ] My code is well documented
- [ ] I have signed my commits
- [ ] My code follows the pattern of the application
- [ ] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced chat labeling: new DMs now include recipient identifiers in the name and a DM ID in the description for clearer context.
- Bug Fixes
  - Prevents duplicate DM group creation by skipping processing when a DM has already been handled, improving reliability.
  - Avoids reprocessing of DM-related webhooks by detecting DM IDs early and exiting safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->