### PR TITLE
hotfix: remove chat updation from services right after sending a message

### DIFF
--- a/platforms/pictique-api/src/services/ChatService.ts
+++ b/platforms/pictique-api/src/services/ChatService.ts
@@ -43,10 +43,10 @@ export class ChatService {
 
         // Filter chats that have exactly the same participants (order doesn't matter)
         const sortedParticipantIds = participantIds.sort();
-        
+
         for (const chat of chats) {
             const chatParticipantIds = chat.participants.map(p => p.id).sort();
-            
+
             if (chatParticipantIds.length === sortedParticipantIds.length &&
                 chatParticipantIds.every((id, index) => id === sortedParticipantIds[index])) {
                 return chat;
@@ -162,11 +162,7 @@ export class ChatService {
         });
 
         const savedMessage = await this.messageRepository.save(message);
-        
-        // Update the chat's updatedAt timestamp to reflect the latest message
-        chat.updatedAt = new Date();
-        await this.chatRepository.save(chat);
-        
+
         console.log("Sent event", `chat:${chatId}`);
         this.eventEmitter.emit(`chat:${chatId}`, [savedMessage]);
 
@@ -317,13 +313,13 @@ export class ChatService {
         const sortedChats = chatsWithRelations.sort((a, b) => {
             const aLatestMessage = a.messages[a.messages.length - 1];
             const bLatestMessage = b.messages[b.messages.length - 1];
-            
+
             if (!aLatestMessage && !bLatestMessage) {
                 return b.createdAt.getTime() - a.createdAt.getTime();
             }
             if (!aLatestMessage) return 1;
             if (!bLatestMessage) return -1;
-            
+
             return bLatestMessage.createdAt.getTime() - aLatestMessage.createdAt.getTime();
         });
 

--- a/platforms/pictique-api/src/services/MessageService.ts
+++ b/platforms/pictique-api/src/services/MessageService.ts
@@ -23,14 +23,6 @@ export class MessageService {
         });
 
         const savedMessage = await this.messageRepository.save(message);
-
-        // Update the chat's updatedAt timestamp to reflect the latest message
-        const chat = await this.chatRepository.findOneBy({ id: chatId });
-        if (chat) {
-            chat.updatedAt = new Date();
-            await this.chatRepository.save(chat);
-        }
-
         return savedMessage;
     }
 


### PR DESCRIPTION
# Description of change

remove, chat updation handlers from services.

## Issue Number

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

## Change checklist

- [ ] I have ensured that the CI Checks pass locally
- [ ] I have removed any unnecessary logic
- [ ] My code is well documented
- [ ] I have signed my commits
- [ ] My code follows the pattern of the application
- [ ] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the message handling workflow to prevent automatic updates to chat timestamps when messages are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->