### PR TITLE
chore: add DB_CA_CERT option to postgres db connections for SSL

### DIFF
--- a/infrastructure/evault-core/src/config/database.ts
+++ b/infrastructure/evault-core/src/config/database.ts
@@ -15,4 +15,10 @@ export const AppDataSource = new DataSource({
     migrations: [join(__dirname, "../migrations/*.{ts,js}")],
     migrationsTableName: "migrations",
     subscribers: [],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 }) 

--- a/infrastructure/evault-core/src/core/provisioning/config/database.ts
+++ b/infrastructure/evault-core/src/core/provisioning/config/database.ts
@@ -15,5 +15,11 @@ export const ProvisioningDataSource = new DataSource({
     migrations: [],
     migrationsTableName: "migrations",
     subscribers: [],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 });
 

--- a/platforms/cerberus/src/database/data-source.ts
+++ b/platforms/cerberus/src/database/data-source.ts
@@ -28,5 +28,11 @@ export const AppDataSource = new DataSource({
     ],
     migrations: [path.join(__dirname, "migrations", "*.ts")],
     subscribers: [PostgresSubscriber],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 });
 

--- a/platforms/dreamsync-api/src/database/data-source.ts
+++ b/platforms/dreamsync-api/src/database/data-source.ts
@@ -24,6 +24,12 @@ export const dataSourceOptions: DataSourceOptions = {
     migrations: [path.join(__dirname, "migrations", "*.ts")],
     logging: process.env.NODE_ENV === "development",
     subscribers: [PostgresSubscriber],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 };
 
 export const AppDataSource = new DataSource(dataSourceOptions);

--- a/platforms/evoting-api/src/database/data-source.ts
+++ b/platforms/evoting-api/src/database/data-source.ts
@@ -22,6 +22,12 @@ export const dataSourceOptions: DataSourceOptions = {
     migrations: [path.join(__dirname, "migrations", "*.ts")],
     logging: process.env.NODE_ENV === "development",
     subscribers: [PostgresSubscriber],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 };
 
 export const AppDataSource = new DataSource(dataSourceOptions);

--- a/platforms/group-charter-manager-api/src/database/data-source.ts
+++ b/platforms/group-charter-manager-api/src/database/data-source.ts
@@ -18,4 +18,10 @@ export const AppDataSource = new DataSource({
     entities: [User, Group, Message, CharterSignature],
     migrations: [path.join(__dirname, "migrations", "*.ts")],
     subscribers: [PostgresSubscriber],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 }); 

--- a/platforms/pictique-api/src/database/data-source.ts
+++ b/platforms/pictique-api/src/database/data-source.ts
@@ -20,4 +20,10 @@ export const AppDataSource = new DataSource({
     entities: [User, Post, Comment, Message, Chat, MessageReadStatus],
     migrations: [path.join(__dirname, "migrations", "*.ts")],
     subscribers: [PostgresSubscriber],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 });

--- a/platforms/registry/src/config/database.ts
+++ b/platforms/registry/src/config/database.ts
@@ -17,4 +17,10 @@ export const AppDataSource = new DataSource({
     migrations: [join(__dirname, "../migrations/*.{ts,js}")],
     migrationsTableName: "migrations",
     subscribers: [],
+    ssl: process.env.DB_CA_CERT
+        ? {
+              rejectUnauthorized: false,
+              ca: process.env.DB_CA_CERT,
+          }
+        : false,
 }) 


### PR DESCRIPTION
# Description of change

adds additional config for SSL connection in postgres

## Issue Number

## Type of change

- Chore (refactoring, build scripts or anything else that isn't user-facing)

## How the change has been tested

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SSL/TLS encryption for database connections across all platform services. When a CA certificate is provided via environment configuration, database connections automatically use secure TLS. Without configuration, connections operate in standard mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->