### PR TITLE
fix: include link for eID App

### DIFF
--- a/platforms/pictique/src/routes/(auth)/auth/+page.svelte
+++ b/platforms/pictique/src/routes/(auth)/auth/+page.svelte
@@ -151,8 +151,11 @@
 			{#if isMobileDevice()}
 				Login with your <a href={getAppStoreLink()}><b><u>eID Wallet</u></b></a>
 			{:else}
-				Scan the QR code using your <a href={getAppStoreLink()} target="_blank"
-					><b><u class="text-sm">eID App</u></b></a
+				Scan the QR code using your <a
+					href={getAppStoreLink()}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label="eID App (opens in new tab)"><b><u class="text-sm">eID App</u></b></a
 				> to login
 			{/if}
 		</h2>
@@ -167,7 +170,7 @@
 				<div class="flex flex-col items-center gap-4">
 					<a
 						href={getDeepLinkUrl(qrData)}
-						class="rounded-xl bg-gradient-to-r from-[#4D44EF] via-[#F35B5B] to-[#F7A428] px-8 py-4 text-base font-semibold text-white transition-opacity hover:opacity-90"
+						class="rounded-xl bg-linear-to-r from-[#4D44EF] via-[#F35B5B] to-[#F7A428] px-8 py-4 text-base font-semibold text-white transition-opacity hover:opacity-90"
 					>
 						Login with eID Wallet
 					</a>


### PR DESCRIPTION
# Description of change
Use the proper getAppStoreLink() as in the other platforms to get the right link for the eID app.

## Issue Number
Closes #639 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The eID App reference in the authentication flow is now a clickable link to the App Store, opens in a new tab, and includes improved accessibility labeling.

* **Style**
  * Updated the CTA button gradient styling for the non-mobile login area to refresh its visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->