### PR TITLE
fix: prevent Safari iOS 16 crash in charter flow

### DIFF
--- a/platforms/group-charter-manager/.browserslistrc
+++ b/platforms/group-charter-manager/.browserslistrc
@@ -1,0 +1,8 @@
+# Browsers that we support
+# iOS 16+ Safari support
+
+>= 0.5%
+last 2 versions
+not dead
+iOS >= 15
+Safari >= 15

--- a/platforms/group-charter-manager/next-env.d.ts
+++ b/platforms/group-charter-manager/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/platforms/group-charter-manager/next.config.ts
+++ b/platforms/group-charter-manager/next.config.ts
@@ -4,6 +4,12 @@ import path from "path";
 const nextConfig: NextConfig = {
     output: 'standalone',
     outputFileTracingRoot: path.join(__dirname),
+
+    // 🔴 Critical for Safari 16 compatibility
+    transpilePackages: [
+        'marked',
+        '@milkdown/preset-gfm',
+    ],
 };
 
 export default nextConfig;

--- a/platforms/group-charter-manager/src/components/MaintenanceBanner.tsx
+++ b/platforms/group-charter-manager/src/components/MaintenanceBanner.tsx
@@ -1,14 +1,14 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import axios from 'axios';
+import { useEffect, useState } from "react";
+import axios from "axios";
 
 interface Motd {
-    status: 'up' | 'maintenance';
+    status: "up" | "maintenance";
     message: string;
 }
 
-const DISMISSED_KEY = 'maintenance-banner-dismissed';
+const DISMISSED_KEY = "maintenance-banner-dismissed";
 
 export function MaintenanceBanner() {
     const [motd, setMotd] = useState<Motd | null>(null);
@@ -17,17 +17,21 @@ export function MaintenanceBanner() {
     useEffect(() => {
         const fetchMotd = async () => {
             try {
-                const registryUrl = process.env.NEXT_PUBLIC_REGISTRY_URL || 'http://localhost:4321';
+                const registryUrl = process.env.NEXT_PUBLIC_REGISTRY_URL;
+                if (!registryUrl) {
+                    // Skip fetching in local dev if env var not set
+                    return;
+                }
                 const response = await axios.get<Motd>(`${registryUrl}/motd`);
                 setMotd(response.data);
-                
+
                 // Check if this message has been dismissed
-                if (response.data.status === 'maintenance') {
+                if (response.data.status === "maintenance") {
                     const dismissed = localStorage.getItem(DISMISSED_KEY);
                     setIsDismissed(dismissed === response.data.message);
                 }
             } catch (error) {
-                console.error('Failed to fetch motd:', error);
+                console.error("Failed to fetch motd:", error);
             }
         };
 
@@ -41,7 +45,7 @@ export function MaintenanceBanner() {
         }
     };
 
-    if (motd?.status !== 'maintenance' || isDismissed) {
+    if (motd?.status !== "maintenance" || isDismissed) {
         return null;
     }
 
@@ -71,4 +75,3 @@ export function MaintenanceBanner() {
         </div>
     );
 }
-


### PR DESCRIPTION
# Description of change
Fixes a UI crash on Safari iOS 16 when opening the Charter.
- Removed a hardcoded http://localhost fallback causing mixed-content errors in production
- Transpiled markdown-related client dependencies to avoid unsupported RegExp syntax in Safari 16
- Added browserslist config to define supported Safari/iOS targets

This prevents JS execution from failing and keeps the Charter flow usable on iOS 16.

## Issue Number
Closes #636 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested
Changes not tested yet

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maintenance banner notifications can now be dismissed and remain dismissed during your session.

* **Chores**
  * Updated browser compatibility targets to support Safari 16+, iOS 15+, and other modern browsers.
  * Enhanced compatibility with markdown processing libraries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->