### PR TITLE
Fix: prevent back to auth on eID Wallet

### DIFF
--- a/infrastructure/eid-wallet/src/routes/(auth)/+layout.svelte
+++ b/infrastructure/eid-wallet/src/routes/(auth)/+layout.svelte
@@ -44,6 +44,7 @@ onMount(async () => {
         }
     } catch (error) {
         console.error("Error in auth layout guard:", error);
+        guardFailed = true;
     } finally {
         isChecking = false;
     }


### PR DESCRIPTION
# Description of change

Implements a centralized auth guard in (auth)/+layout.svelte. This prevents authenticated users from using the OS back button to return to login/onboarding screens.

## Issue Number

Closes #665

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Tested on virtual device (pixel 7)

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication route guard to protect restricted areas with automatic redirects (to main or login) based on session/onboarding state.
  * Prevents back-navigation after redirect for a smoother flow.
  * Shows a full-screen loading indicator while checking session state.
  * Displays a clear error/guard-failed UI when authentication checks encounter problems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->