### PR TITLE
fix: auth refresh

### DIFF
--- a/infrastructure/eid-wallet/src-tauri/tauri.conf.json
+++ b/infrastructure/eid-wallet/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "eID for W3DS",
     "version": "0.5.0",
-    "identifier": "com.kodski.eid-wallet",
+    "identifier": "foundation.metastate.eid-wallet",
     "build": {
         "beforeDevCommand": "pnpm dev",
         "devUrl": "http://localhost:1420",

--- a/platforms/blabsy-w3ds-auth-api/src/controllers/AuthController.ts
+++ b/platforms/blabsy-w3ds-auth-api/src/controllers/AuthController.ts
@@ -31,14 +31,25 @@ export class AuthController {
 
         this.eventEmitter.on(id, handler);
 
+        // Send heartbeat every 30 seconds to keep connection alive
+        const heartbeatInterval = setInterval(() => {
+            try {
+                res.write(`: heartbeat\n\n`);
+            } catch (error) {
+                clearInterval(heartbeatInterval);
+            }
+        }, 30000);
+
         // Handle client disconnect
         req.on("close", () => {
+            clearInterval(heartbeatInterval);
             this.eventEmitter.off(id, handler);
             res.end();
         });
 
         req.on("error", (error) => {
             console.error("SSE Error:", error);
+            clearInterval(heartbeatInterval);
             this.eventEmitter.off(id, handler);
             res.end();
         });

--- a/platforms/pictique-api/src/controllers/AuthController.ts
+++ b/platforms/pictique-api/src/controllers/AuthController.ts
@@ -34,14 +34,25 @@ export class AuthController {
 
         this.eventEmitter.on(id, handler);
 
+        // Send heartbeat every 30 seconds to keep connection alive
+        const heartbeatInterval = setInterval(() => {
+            try {
+                res.write(`: heartbeat\n\n`);
+            } catch (error) {
+                clearInterval(heartbeatInterval);
+            }
+        }, 30000);
+
         // Handle client disconnect
         req.on("close", () => {
+            clearInterval(heartbeatInterval);
             this.eventEmitter.off(id, handler);
             res.end();
         });
 
         req.on("error", (error) => {
             console.error("SSE Error:", error);
+            clearInterval(heartbeatInterval);
             this.eventEmitter.off(id, handler);
             res.end();
         });


### PR DESCRIPTION
# Description of change

adds heartbeat to keep auth sse connection alive and refreshes qr code every 60 seconds on pictique and blabsy

## Issue Number
Closes #236

## Type of change

- Fix (a change which fixes an issue)


## How the change has been tested
Partial Manual 

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login QR codes and offerings now auto-refresh automatically every 60 seconds, eliminating the need for manual page refresh.

* **Improvements**
  * Enhanced connection stability during authentication flows with keepalive heartbeats for real-time event streams.
  * Updated user messaging to clarify automatic refresh behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->