### PR TITLE
feat: increase body size limit for eVaults

### DIFF
--- a/infrastructure/evault-core/src/index.ts
+++ b/infrastructure/evault-core/src/index.ts
@@ -123,6 +123,7 @@ const initializeEVault = async (provisioningServiceInstance?: ProvisioningServic
     
     fastifyServer = fastify({
         logger: true,
+        bodyLimit: 20 * 1024 * 1024, // 20MB (default is 1MB; needed for createMetaEnvelope etc.)
     });
 
     // Register CORS plugin with relaxed settings

--- a/infrastructure/evault-core/src/test-utils/e2e-setup.ts
+++ b/infrastructure/evault-core/src/test-utils/e2e-setup.ts
@@ -120,7 +120,10 @@ export async function setupE2ETestServer(
     const yoga = graphqlServer.init();
 
     // Setup Fastify server
-    const fastifyServer = fastify({ logger: false });
+    const fastifyServer = fastify({
+        logger: false,
+        bodyLimit: 20 * 1024 * 1024, // 20MB, match production limit
+    });
     await registerHttpRoutes(fastifyServer, evaultInstance, provisioningService, dbService);
 
     // Register GraphQL endpoint


### PR DESCRIPTION
# Description of change

Set bodyLimit: 20 * 1024 * 1024 (20MB) in the fastify({ ... }) options so the default 1MB limit no longer applies to GraphQL (including storeMetaEnvelope / createMetaEnvelope) and other HTTP routes.


## Issue Number

## Type of change

- Update (a change which updates existing functionality)


## How the change has been tested

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Increased the maximum request payload size limit to 20 MB, enabling the application to handle larger file uploads and submissions across all environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->