### PR TITLE
fix(eid-wallet): bump barcode-scanner to 2.4.5 to fix iOS cancel crash

### DIFF
--- a/infrastructure/eid-wallet/src-tauri/Cargo.lock
+++ b/infrastructure/eid-wallet/src-tauri/Cargo.lock
@@ -3971,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-barcode-scanner"
-version = "2.4.4"
+version = "2.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485cbcf227f04117e930be748ea71d835900466dcd1d455d5ec284d36107a305"
+checksum = "d3b68f0e3782b61a6e16a67380be40226e2b7233f3e36dadf6e5d03f07d2e7b3"
 dependencies = [
  "log",
  "serde",


### PR DESCRIPTION
Fixes the constant iOS crash when the QR/barcode scanner is closed or cancelled.

Root cause: in tauri-plugin-barcode-scanner 2.4.4 the native cancel() handler calls destroy() -> dismantleCamera() -> cameraView.removeFromSuperview() directly on Tauri's background dispatch queue. That is a UIKit call off the main thread, so iOS aborts with SIGABRT (NSAssertionHandler). scan() and the other handlers already wrap their UIKit work in DispatchQueue.main.async; cancel() in 2.4.4 did not. Android is unaffected (no equivalent main-thread assertion).

Fix: upstream 2.4.5 wraps the whole cancel() body in DispatchQueue.main.async (tauri-apps/plugins-workspace#3393). Verified against the 2.4.5 source. Cargo.toml already allows it (= "2"), so this is a lockfile-only bump 2.4.4 -> 2.4.5. The iOS Swift is compiled from the vendored crate, so no Cargo.toml or JS change is needed.

Requires an iOS rebuild and a new TestFlight build to ship.