### PR TITLE
Feat: edit Display Name & remove "continue" step

### DIFF
--- a/infrastructure/eid-wallet/src/lib/fragments/SplashScreen/SplashScreen.svelte
+++ b/infrastructure/eid-wallet/src/lib/fragments/SplashScreen/SplashScreen.svelte
@@ -11,9 +11,6 @@ interface ISplashScreenProps {
     showDrawer?: boolean;
     oncreate?: () => void;
     onrestore?: () => void;
-    /** When provided, the drawer renders a single "Continue" button instead
-     *  of the Create / Restore pair (returning-user variant). */
-    oncontinue?: () => void;
 }
 
 const {
@@ -21,7 +18,6 @@ const {
     showDrawer = false,
     oncreate,
     onrestore,
-    oncontinue,
 }: ISplashScreenProps = $props();
 
 // Roboto Condensed ships with font-display: swap, so without this gate the
@@ -97,52 +93,42 @@ onMount(async () => {
             class="absolute inset-x-0 bottom-0 bg-white rounded-t-3xl px-5 pt-5 flex flex-col gap-3"
             style="padding-bottom: max(20px, env(safe-area-inset-bottom));"
         >
-            {#if oncontinue}
-                <ButtonAction
-                    variant="solid"
-                    callback={oncontinue}
-                    class="w-full uppercase tracking-wide active:bg-primary-400"
+            <ButtonAction
+                variant="solid"
+                callback={oncreate}
+                class="w-full uppercase tracking-wide active:bg-primary-400"
+            >
+                Create Digital Self
+            </ButtonAction>
+            <ButtonAction
+                variant="soft"
+                callback={onrestore}
+                class="w-full uppercase tracking-wide text-black active:bg-primary-200"
+            >
+                Restore Digital Self
+            </ButtonAction>
+            <p
+                class="text-center font-medium text-md text-black-700/50 leading-normal"
+            >
+                By continuing you agree to our
+                <a
+                    href="https://metastate.foundation/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary"
                 >
-                    Continue
-                </ButtonAction>
-            {:else}
-                <ButtonAction
-                    variant="solid"
-                    callback={oncreate}
-                    class="w-full uppercase tracking-wide active:bg-primary-400"
+                    Terms &amp; Conditions
+                </a>
+                and
+                <a
+                    href="https://metastate.foundation/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary"
                 >
-                    Create Digital Self
-                </ButtonAction>
-                <ButtonAction
-                    variant="soft"
-                    callback={onrestore}
-                    class="w-full uppercase tracking-wide text-black active:bg-primary-200"
-                >
-                    Restore Digital Self
-                </ButtonAction>
-                <p
-                    class="text-center font-medium text-md text-black-700/50 leading-normal"
-                >
-                    By continuing you agree to our
-                    <a
-                        href="https://metastate.foundation/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary"
-                    >
-                        Terms &amp; Conditions
-                    </a>
-                    and
-                    <a
-                        href="https://metastate.foundation/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-primary"
-                    >
-                        Privacy Policy
-                    </a>
-                </p>
-            {/if}
+                    Privacy Policy
+                </a>
+            </p>
         </div>
     {/if}
 </div>

--- a/infrastructure/eid-wallet/src/lib/ui/PinDots/PinDots.svelte
+++ b/infrastructure/eid-wallet/src/lib/ui/PinDots/PinDots.svelte
@@ -5,15 +5,17 @@ interface IPinDotsProps {
     pin: string;
     autofocus?: boolean;
     class?: string;
+    /** Bind a reference to the underlying hidden input so the parent can
+     *  trigger focus from elsewhere (e.g. a background tap on /login). */
+    inputEl?: HTMLInputElement | undefined;
 }
 
 let {
     pin = $bindable(""),
     autofocus = true,
     class: classes = "",
+    inputEl = $bindable<HTMLInputElement | undefined>(undefined),
 }: IPinDotsProps = $props();
-
-let inputEl: HTMLInputElement | undefined = $state();
 
 // Android WebView only attaches its IME input connection after first paint;
 // focus before that is a no-op for the soft keyboard.

--- a/infrastructure/eid-wallet/src/lib/utils/personalBinding.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/personalBinding.ts
@@ -176,6 +176,35 @@ export async function createSecurityQuestion(
     return unwrapCreate(result);
 }
 
+/**
+ * Re-issue the user's self-binding doc with a new display name. Same shape
+ * as the doc created during onboarding (kind:"self"). Callers pair this
+ * with `deletePersonalBinding(oldId)` to drop the previous version —
+ * evault-core has no update mutation.
+ */
+export async function createSelfBindingDoc(
+    gqlUrl: string,
+    ownerEname: string,
+    ownerSignature: OwnerSignature,
+    name: string,
+): Promise<string> {
+    const subject = normalizeEname(ownerEname);
+    const result = await vaultGqlRequest<CreateBindingDocResult>(
+        gqlUrl,
+        ownerEname,
+        CREATE_BINDING_DOC_MUTATION,
+        {
+            input: {
+                subject,
+                type: "self",
+                data: { kind: "self", name },
+                ownerSignature,
+            },
+        },
+    );
+    return unwrapCreate(result);
+}
+
 // ---------------------------------------------------------------------------
 // Hash / validate
 // ---------------------------------------------------------------------------

--- a/infrastructure/eid-wallet/src/lib/utils/postLogin.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/postLogin.ts
@@ -62,6 +62,7 @@ export async function continueAfterSuccessfulAuth(
         } catch (error) {
             console.error("Error processing pending deep link:", error);
             sessionStorage.removeItem("pendingDeepLink");
+            sessionStorage.removeItem("deepLinkData");
         }
     }
 

--- a/infrastructure/eid-wallet/src/lib/utils/postLogin.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/postLogin.ts
@@ -1,0 +1,69 @@
+import { goto } from "$app/navigation";
+import type { GlobalState } from "$lib/global";
+
+/**
+ * Shared post-authentication routine: fires the background eVault chores
+ * (health check, public-key sync, push registration) and routes the user
+ * either to the deep-link target waiting in sessionStorage or to /main.
+ *
+ * Called from both the splash (when biometric auth succeeds over the
+ * splash screen) and from /login (after PIN or fallback biometric).
+ * Keeping the logic here means we don't have to flash the user through
+ * /login on biometric success.
+ */
+export async function continueAfterSuccessfulAuth(
+    gs: GlobalState,
+): Promise<void> {
+    // Fire-and-forget post-login chores. They hit the network with no client
+    // timeout, so awaiting them here can strand the user on a spinner — the
+    // app pages will retry as needed.
+    try {
+        const vault = await gs.vaultController.vault;
+        if (vault?.ename) {
+            const ename = vault.ename;
+            void gs.vaultController
+                .checkHealth(ename)
+                .then((health) => {
+                    if (!health.healthy) {
+                        console.warn(
+                            "eVault health check failed:",
+                            health.error,
+                        );
+                    }
+                })
+                .catch((error) =>
+                    console.error("eVault health check error:", error),
+                );
+            void gs.vaultController
+                .syncPublicKey(ename)
+                .catch((error) =>
+                    console.error("Error syncing public key:", error),
+                );
+            void gs.notificationService
+                .registerDevice(ename)
+                .catch((error) =>
+                    console.error(
+                        "Error registering device for notifications:",
+                        error,
+                    ),
+                );
+        }
+    } catch (error) {
+        console.error("Error reading vault during login:", error);
+    }
+
+    const pendingDeepLink = sessionStorage.getItem("pendingDeepLink");
+    if (pendingDeepLink) {
+        try {
+            sessionStorage.setItem("deepLinkData", pendingDeepLink);
+            sessionStorage.removeItem("pendingDeepLink");
+            await goto("/scan-qr");
+            return;
+        } catch (error) {
+            console.error("Error processing pending deep link:", error);
+            sessionStorage.removeItem("pendingDeepLink");
+        }
+    }
+
+    await goto("/main");
+}

--- a/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
@@ -18,6 +18,7 @@ let cachedUserData: Record<string, unknown> | undefined;
 let cachedEname: string | undefined;
 let cachedIsFake: boolean | undefined;
 let cachedLegalId: LegalIdDoc | null = null;
+let cachedDisplayName: string | undefined;
 let cachedSocialBindingCount = 0;
 let cachedSocialBindingPreview: SocialBindingDisplay[] = [];
 let hasEverLoaded = false;
@@ -88,6 +89,10 @@ let toastMessage = $state("");
 // binding doc as the authoritative signal.
 let isFake = $state<boolean | undefined>(cachedIsFake);
 let legalId = $state<LegalIdDoc | null>(cachedLegalId);
+// Display name from the self-binding doc — the one the user typed at
+// registration. Never gets overwritten by KYC the way userController.user.name
+// does, so this stays as the user's chosen handle on the home greeting.
+let displayName = $state<string | undefined>(cachedDisplayName);
 let kycOpen = $state(false);
 let eVaultInfoOpen = $state(false);
 let bindingDocsInfoOpen = $state(false);
@@ -152,12 +157,20 @@ async function loadBindingDocuments(): Promise<void> {
         const edges: { node: { parsed: ParsedBindingDoc | null } }[] =
             json?.data?.bindingDocuments?.edges ?? [];
 
-        const idDoc = edges
+        const parsedDocs = edges
             .map((e) => e.node.parsed)
-            .find((p): p is ParsedBindingDoc => p?.type === "id_document");
+            .filter((p): p is ParsedBindingDoc => p !== null);
 
+        const idDoc = parsedDocs.find((p) => p.type === "id_document");
         legalId = idDoc ? toLegalIdDoc(idDoc) : null;
         cachedLegalId = legalId;
+
+        const selfDoc = parsedDocs.find((p) => p.type === "self");
+        const selfName = selfDoc?.data?.name;
+        if (typeof selfName === "string" && selfName.trim()) {
+            displayName = selfName.trim();
+            cachedDisplayName = displayName;
+        }
     } catch (err) {
         console.warn("[main] Failed to load binding documents:", err);
     }
@@ -725,7 +738,7 @@ async function refreshBindings(): Promise<void> {
             >
                 <Greeting
                     greeting={tourGreeting}
-                    name={(userData?.name as string) ?? ""}
+                    name={displayName ?? (userData?.name as string) ?? ""}
                     {notificationCount}
                     {tourActive}
                 />

--- a/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
@@ -19,6 +19,7 @@ let cachedEname: string | undefined;
 let cachedIsFake: boolean | undefined;
 let cachedLegalId: LegalIdDoc | null = null;
 let cachedDisplayName: string | undefined;
+let cachedSelfDocId: string | undefined;
 let cachedSocialBindingCount = 0;
 let cachedSocialBindingPreview: SocialBindingDisplay[] = [];
 let hasEverLoaded = false;
@@ -42,13 +43,19 @@ import {
     fetchSocialBindings,
     resolveVaultUri,
 } from "$lib/utils";
+import { getCanonicalBindingDocString } from "$lib/utils/bindingDocHash";
 import { replaceAll as replaceAllPersonal } from "$lib/stores/personalBinding";
-import { loadPersonalBindings } from "$lib/utils/personalBinding";
+import {
+    createSelfBindingDoc,
+    deletePersonalBinding,
+    loadPersonalBindings,
+} from "$lib/utils/personalBinding";
 import { getContext, onDestroy, onMount, tick } from "svelte";
 import { Shadow } from "svelte-loading-spinners";
 import { fly } from "svelte/transition";
 import AppsMarketplace from "./components/AppsMarketplace.svelte";
 import BindingDocuments from "./components/BindingDocuments.svelte";
+import EditNameSheet from "./components/EditNameSheet.svelte";
 import ENameCard from "./components/ENameCard.svelte";
 import EVaultCard from "./components/EVaultCard.svelte";
 import Greeting from "./components/Greeting.svelte";
@@ -93,6 +100,13 @@ let legalId = $state<LegalIdDoc | null>(cachedLegalId);
 // registration. Never gets overwritten by KYC the way userController.user.name
 // does, so this stays as the user's chosen handle on the home greeting.
 let displayName = $state<string | undefined>(cachedDisplayName);
+// MetaEnvelope id of the current self-binding doc. Captured at load so the
+// edit flow can delete the old doc after writing a new one — evault-core has
+// no update mutation, so the only way to "rename" is create-then-delete.
+let selfDocId = $state<string | undefined>(cachedSelfDocId);
+let editNameOpen = $state(false);
+let editNameSaving = $state(false);
+let editNameError = $state<string | null>(null);
 let kycOpen = $state(false);
 let eVaultInfoOpen = $state(false);
 let bindingDocsInfoOpen = $state(false);
@@ -147,35 +161,130 @@ async function loadBindingDocuments(): Promise<void> {
             body: JSON.stringify({
                 query: `query {
                     bindingDocuments(first: 50) {
-                        edges { node { parsed } }
+                        edges { node { id parsed } }
                     }
                 }`,
             }),
         });
 
         const json = await res.json();
-        const edges: { node: { parsed: ParsedBindingDoc | null } }[] =
-            json?.data?.bindingDocuments?.edges ?? [];
+        const edges: {
+            node: { id: string; parsed: ParsedBindingDoc | null };
+        }[] = json?.data?.bindingDocuments?.edges ?? [];
 
-        const parsedDocs = edges
-            .map((e) => e.node.parsed)
-            .filter((p): p is ParsedBindingDoc => p !== null);
+        const docs = edges
+            .map((e) => ({ id: e.node.id, parsed: e.node.parsed }))
+            .filter(
+                (d): d is { id: string; parsed: ParsedBindingDoc } =>
+                    d.parsed !== null,
+            );
 
-        const idDoc = parsedDocs.find((p) => p.type === "id_document");
-        legalId = idDoc ? toLegalIdDoc(idDoc) : null;
+        const idDocEntry = docs.find((d) => d.parsed.type === "id_document");
+        legalId = idDocEntry ? toLegalIdDoc(idDocEntry.parsed) : null;
         cachedLegalId = legalId;
 
-        const selfDoc = parsedDocs.find((p) => p.type === "self");
-        const selfName = selfDoc?.data?.name;
+        const selfDocEntry = docs.find((d) => d.parsed.type === "self");
+        const selfName = selfDocEntry?.parsed.data?.name;
         if (typeof selfName === "string" && selfName.trim()) {
             displayName = selfName.trim();
             cachedDisplayName = displayName;
         }
+        selfDocId = selfDocEntry?.id;
+        cachedSelfDocId = selfDocId;
     } catch (err) {
         console.warn("[main] Failed to load binding documents:", err);
     }
 
     await loadSocialBindings();
+}
+
+// Edit the display name by writing a new self-binding doc and deleting the
+// old one. evault-core exposes no update mutation, so this create+delete
+// pair is the only path. If the delete fails we leave the orphan in place —
+// the next load picks the most-recent self doc by timestamp anyway.
+async function handleEditNameSave(newName: string): Promise<void> {
+    if (!globalState) {
+        editNameError = "Wallet not ready.";
+        return;
+    }
+    const trimmed = newName.trim();
+    if (!trimmed) {
+        editNameError = "Please enter a name.";
+        return;
+    }
+    if (trimmed === displayName) {
+        editNameOpen = false;
+        return;
+    }
+
+    editNameSaving = true;
+    editNameError = null;
+
+    try {
+        const vault = await globalState.vaultController.vault;
+        if (!vault?.uri || !vault?.ename) {
+            throw new Error("No eVault available");
+        }
+        const ownerEname = vault.ename.startsWith("@")
+            ? vault.ename
+            : `@${vault.ename}`;
+        const gqlUrl = new URL("/graphql", vault.uri).toString();
+
+        const data = { kind: "self", name: trimmed };
+        const canonical = getCanonicalBindingDocString({
+            subject: ownerEname,
+            type: "self",
+            data,
+        });
+        const signature = await globalState.keyService.sign(canonical);
+        const ownerSignature = {
+            signer: ownerEname,
+            signature,
+            timestamp: new Date().toISOString(),
+        };
+
+        const newId = await createSelfBindingDoc(
+            gqlUrl,
+            ownerEname,
+            ownerSignature,
+            trimmed,
+        );
+
+        const oldId = selfDocId;
+        displayName = trimmed;
+        cachedDisplayName = trimmed;
+        selfDocId = newId;
+        cachedSelfDocId = newId;
+
+        // Mirror to userController so accordions/cards that still read from
+        // there stay consistent until their own loaders re-run.
+        if (userData) {
+            userData = { ...userData, name: trimmed };
+            cachedUserData = userData;
+            globalState.userController.user = userData as Record<string, string>;
+        }
+
+        if (oldId && oldId !== newId) {
+            try {
+                await deletePersonalBinding(gqlUrl, ownerEname, oldId);
+            } catch (err) {
+                console.warn(
+                    "[main] Couldn't delete old self-binding; load dedupe will handle it",
+                    err,
+                );
+            }
+        }
+
+        editNameOpen = false;
+    } catch (err) {
+        console.error("[main] Edit name failed:", err);
+        editNameError =
+            err instanceof Error
+                ? err.message
+                : "Couldn't save your new name. Please try again.";
+    } finally {
+        editNameSaving = false;
+    }
 }
 
 // Hydrate the personalBinding store from the caller's vault so the
@@ -741,6 +850,10 @@ async function refreshBindings(): Promise<void> {
                     name={displayName ?? (userData?.name as string) ?? ""}
                     {notificationCount}
                     {tourActive}
+                    onedit={() => {
+                        editNameError = null;
+                        editNameOpen = true;
+                    }}
                 />
             </div>
         {/if}
@@ -869,6 +982,14 @@ async function refreshBindings(): Promise<void> {
     bind:isOpen={socialDrawerOpen}
     {globalState}
     onbound={handleSocialBound}
+/>
+
+<EditNameSheet
+    bind:isOpen={editNameOpen}
+    currentName={displayName ?? (userData?.name as string) ?? ""}
+    saving={editNameSaving}
+    error={editNameError}
+    onsave={handleEditNameSave}
 />
 
 <InfoDrawer bind:isOpen={eVaultInfoOpen} title="What is eVault?">

--- a/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
@@ -715,7 +715,7 @@ async function refreshBindings(): Promise<void> {
 {:else}
     <div
         class="relative transition-transform duration-500 ease-out will-change-transform"
-        style="padding-top: max(12px, env(safe-area-inset-top)); padding-bottom: max(16px, env(safe-area-inset-bottom)); transform: translateY(-{tourOffset}px);"
+        style="padding-bottom: max(16px, env(safe-area-inset-bottom)); transform: translateY(-{tourOffset}px);"
     >
         {#if pageReady}
             <div

--- a/infrastructure/eid-wallet/src/routes/(app)/main/components/EditNameSheet.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/components/EditNameSheet.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+import { ButtonAction } from "$lib/ui";
+import BottomSheet from "$lib/ui/BottomSheet/BottomSheet.svelte";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/svelte";
+
+interface IEditNameSheetProps {
+    isOpen: boolean;
+    currentName?: string;
+    saving?: boolean;
+    error?: string | null;
+    onsave?: (name: string) => void;
+}
+
+let {
+    isOpen = $bindable(),
+    currentName = "",
+    saving = false,
+    error = null,
+    onsave,
+}: IEditNameSheetProps = $props();
+
+let name = $state("");
+
+// Seed the input from the prop whenever the sheet opens. Doing it in an
+// effect rather than at script-eval time means the user's previous typing
+// doesn't linger across opens.
+$effect(() => {
+    if (!isOpen) return;
+    name = currentName;
+});
+
+const trimmed = $derived(name.trim());
+const canSave = $derived(
+    trimmed.length > 0 && trimmed !== currentName.trim() && !saving,
+);
+
+function save() {
+    if (!canSave) return;
+    onsave?.(trimmed);
+}
+
+function close() {
+    if (saving) return;
+    isOpen = false;
+}
+</script>
+
+<BottomSheet bind:isOpen dismissible={!saving}>
+    <header class="flex items-center justify-between">
+        <h2 class="text-2xl font-bold text-black-900">Edit name</h2>
+        <button
+            type="button"
+            aria-label="Close"
+            class="w-9 h-9 rounded-full bg-black-50 flex items-center justify-center active:opacity-70 disabled:opacity-40"
+            onclick={close}
+            disabled={saving}
+        >
+            <HugeiconsIcon icon={Cancel01Icon} size={18} strokeWidth={2} />
+        </button>
+    </header>
+
+    <div class="flex flex-col gap-4">
+        <p class="text-black-500 leading-snug">
+            This is the name shown on your home screen. Your legal name (from
+            your verified ID) and your eName are not affected.
+        </p>
+
+        <div>
+            <label for="edit-name" class="block text-black-500 mb-2">
+                Display name
+            </label>
+            <input
+                id="edit-name"
+                type="text"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="words"
+                spellcheck="false"
+                bind:value={name}
+                maxlength={64}
+                disabled={saving}
+                class="w-full bg-card-alternative rounded-full px-5 py-4 placeholder:text-black-300 outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+            />
+        </div>
+
+        {#if error}
+            <p class="text-sm text-danger" role="alert">{error}</p>
+        {/if}
+
+        <ButtonAction
+            class="w-full"
+            callback={save}
+            disabled={!canSave}
+            isLoading={saving}
+            blockingClick
+        >
+            Save
+        </ButtonAction>
+    </div>
+</BottomSheet>

--- a/infrastructure/eid-wallet/src/routes/(app)/main/components/Greeting.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/components/Greeting.svelte
@@ -30,11 +30,6 @@ const {
             <h2 class="text-display font-bold font-condensed text-black">
                 {name}
             </h2>
-            <!-- Edit-name button hidden until the backend supports updating
-                 the self-binding document. evault-core only exposes
-                 createBindingDocument today; there's no update mutation, and
-                 patching the underlying MetaEnvelope would invalidate the
-                 existing signature. Re-enable once that path lands. -->
             {#if !tourActive}
                 <button
                     type="button"

--- a/infrastructure/eid-wallet/src/routes/(app)/main/components/Greeting.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/components/Greeting.svelte
@@ -35,7 +35,7 @@ const {
                  createBindingDocument today; there's no update mutation, and
                  patching the underlying MetaEnvelope would invalidate the
                  existing signature. Re-enable once that path lands. -->
-            <!-- {#if !tourActive}
+            {#if !tourActive}
                 <button
                     type="button"
                     aria-label="Edit name"
@@ -44,7 +44,7 @@ const {
                 >
                     <EditIcon size={18} />
                 </button>
-            {/if} -->
+            {/if}
         </div>
     </div>
 

--- a/infrastructure/eid-wallet/src/routes/(auth)/login/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(auth)/login/+page.svelte
@@ -4,6 +4,7 @@ import { keyboardInset } from "$lib/actions/keyboardInset";
 import type { GlobalState } from "$lib/global";
 import { LoadingSheet, PinDots } from "$lib/ui";
 import * as Button from "$lib/ui/Button";
+import { continueAfterSuccessfulAuth } from "$lib/utils/postLogin";
 import {
     type AuthOptions,
     authenticate,
@@ -12,10 +13,25 @@ import {
 import { getContext, onMount } from "svelte";
 import StepHeader from "../onboarding/steps/StepHeader.svelte";
 
+// Splash sets this when it has already tried biometric over its own screen.
+// /login then skips re-prompting and just shows the PIN UI.
+const BIOMETRIC_ATTEMPTED_KEY = "biometricAttemptedOnSplash";
+
 let pin = $state("");
 let isError = $state(false);
 let isPostAuthLoading = $state(false);
 let hasPendingDeepLink = $state(false);
+let pinInput = $state<HTMLInputElement | undefined>(undefined);
+
+// Refocus the hidden PIN input on background taps so the user doesn't have
+// to aim for the dots themselves to summon the keyboard. We skip taps that
+// land on interactive elements so their own click handlers (Clear PIN, back
+// chevron, etc.) still behave normally.
+function handleBackgroundClick(e: MouseEvent) {
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('button, a, [role="button"]')) return;
+    pinInput?.focus({ preventScroll: true });
+}
 
 const getGlobalState = getContext<() => GlobalState | undefined>("globalState");
 let globalState: GlobalState | undefined = $state(undefined);
@@ -35,61 +51,6 @@ async function clearPin() {
     if (isPostAuthLoading) return;
     pin = "";
     isError = false;
-}
-
-async function continueAfterSuccessfulAuth(gs: GlobalState) {
-    // Fire-and-forget post-login chores. These hit the network with no client
-    // timeout, so awaiting them here can strand the user on the "Logging you
-    // in…" spinner indefinitely. The app pages will retry as needed.
-    try {
-        const vault = await gs.vaultController.vault;
-        if (vault?.ename) {
-            const ename = vault.ename;
-            void gs.vaultController
-                .checkHealth(ename)
-                .then((health) => {
-                    if (!health.healthy) {
-                        console.warn(
-                            "eVault health check failed:",
-                            health.error,
-                        );
-                    }
-                })
-                .catch((error) =>
-                    console.error("eVault health check error:", error),
-                );
-            void gs.vaultController
-                .syncPublicKey(ename)
-                .catch((error) =>
-                    console.error("Error syncing public key:", error),
-                );
-            void gs.notificationService
-                .registerDevice(ename)
-                .catch((error) =>
-                    console.error(
-                        "Error registering device for notifications:",
-                        error,
-                    ),
-                );
-        }
-    } catch (error) {
-        console.error("Error reading vault during login:", error);
-    }
-
-    const pendingDeepLink = sessionStorage.getItem("pendingDeepLink");
-    if (pendingDeepLink) {
-        try {
-            sessionStorage.setItem("deepLinkData", pendingDeepLink);
-            sessionStorage.removeItem("pendingDeepLink");
-            await goto("/scan-qr");
-            return;
-        } catch (error) {
-            console.error("Error processing pending deep link:", error);
-            sessionStorage.removeItem("pendingDeepLink");
-        }
-    }
-
-    await goto("/main");
 }
 
 async function verifyAndAdvance(currentPin: string) {
@@ -135,6 +96,16 @@ onMount(async () => {
     const pendingDeepLink = sessionStorage.getItem("pendingDeepLink");
     hasPendingDeepLink = !!pendingDeepLink;
 
+    // If the splash already prompted biometric over its own screen, skip the
+    // retry here and let the user enter their PIN. The flag survives the
+    // route transition but is single-use.
+    const biometricHandledBySplash =
+        sessionStorage.getItem(BIOMETRIC_ATTEMPTED_KEY) === "true";
+    if (biometricHandledBySplash) {
+        sessionStorage.removeItem(BIOMETRIC_ATTEMPTED_KEY);
+        return;
+    }
+
     // Try biometric first if available.
     if (
         (await gs.securityController.biometricSupport) &&
@@ -155,8 +126,15 @@ onMount(async () => {
 });
 </script>
 
+<!-- The PIN input is the only meaningful interaction here; keyboard users
+     focus it directly via tab. The pointer-only listener just refocuses the
+     same input when sighted users tap the background, so there's no
+     keyboard interaction worth mirroring. -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <main
     use:keyboardInset
+    onclick={handleBackgroundClick}
     class="h-dvh overflow-hidden px-[5vw] flex flex-col bg-white"
     style="padding-top: max(2svh, env(safe-area-inset-top)); padding-bottom: calc(max(16px, env(safe-area-inset-bottom)) + var(--kb-inset, 0px));"
 >
@@ -173,7 +151,7 @@ onMount(async () => {
     {/if}
 
     <section class="flex-1 flex flex-col items-center justify-center gap-6">
-        <PinDots bind:pin />
+        <PinDots bind:pin bind:inputEl={pinInput} />
 
         {#if isError}
             <p class="text-danger text-sm font-medium" role="alert">

--- a/infrastructure/eid-wallet/src/routes/(auth)/onboarding/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(auth)/onboarding/+page.svelte
@@ -1015,7 +1015,7 @@ onMount(async () => {
                 >
                 and
                 <a
-                    href="https://metastate.foundation/"
+                    href="https://metastate.foundation/privacy"
                     rel="noopener noreferrer"
                     target="_blank"
                     class="text-primary underline underline-offset-4"

--- a/infrastructure/eid-wallet/src/routes/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/+page.svelte
@@ -3,7 +3,24 @@ import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import SplashScreen from "$lib/fragments/SplashScreen/SplashScreen.svelte";
 import type { GlobalState } from "$lib/global";
+import { continueAfterSuccessfulAuth } from "$lib/utils/postLogin";
+import {
+    type AuthOptions,
+    authenticate,
+    checkStatus,
+} from "@tauri-apps/plugin-biometric";
 import { getContext, onMount } from "svelte";
+
+const BIOMETRIC_ATTEMPTED_KEY = "biometricAttemptedOnSplash";
+
+const authOpts: AuthOptions = {
+    allowDeviceCredential: false,
+    cancelTitle: "Cancel",
+    fallbackTitle: "Please enter your PIN",
+    title: "Login",
+    subtitle: "Please authenticate to continue",
+    confirmationRequired: true,
+};
 
 const getGlobalState = getContext<() => GlobalState | undefined>("globalState");
 
@@ -15,12 +32,9 @@ if (skipIntro) sessionStorage.removeItem("splashImmediate");
 
 // false = state A (logo "closed"); true = state B (tagline revealed).
 let splashOpen = $state(skipIntro);
-// true = state C (bottom drawer revealed) — Create/Restore for new users,
-// single Continue for returning users.
+// true = state C (bottom drawer revealed) — Create/Restore for new users.
+// Returning users skip the drawer entirely and auto-redirect to /login.
 let splashShowDrawer = $state(skipIntro);
-// Set for returning users; the Continue tap navigates here and carries the
-// user gesture Android needs to auto-open the soft keyboard on /login.
-let returningUserTarget = $state<string | null>(null);
 
 async function handleCreateDigitalSelf() {
     // The mount-guard flag for /onboarding is set centrally by the layout's
@@ -31,10 +45,6 @@ async function handleCreateDigitalSelf() {
 
 async function handleRestoreDigitalSelf() {
     await goto("/recover");
-}
-
-async function handleContinue() {
-    if (returningUserTarget) await goto(returningUserTarget);
 }
 
 onMount(async () => {
@@ -71,13 +81,53 @@ onMount(async () => {
     }
 
     if (onboardingComplete && userExists) {
-        // Returning user — show a Continue CTA instead of auto-redirecting,
-        // so the tap can carry the gesture into /login's keyboard auto-open.
+        // Returning user.
         const pinHash = globalState
             ? await globalState.securityController.pinHash
             : null;
-        returningUserTarget = pinHash ? "/login" : "/onboarding";
-        splashShowDrawer = true;
+
+        // If no PIN is set we bounce back to onboarding to recover; no
+        // biometric prompt makes sense from that state.
+        if (!pinHash) {
+            await goto("/onboarding");
+            return;
+        }
+
+        // Fire biometric over the splash itself so the prompt isn't competing
+        // with the /login slide-in. On success we run the post-auth chores
+        // and route straight to /main (no /login flash). On cancel/fail we
+        // slide into /login with a sessionStorage flag so /login knows the
+        // biometric attempt already happened and skips re-prompting.
+        let biometricAvailable = false;
+        try {
+            biometricAvailable =
+                !!globalState &&
+                (await globalState.securityController.biometricSupport) &&
+                (await checkStatus()).isAvailable;
+        } catch (error) {
+            console.error("Biometric availability check failed:", error);
+        }
+
+        if (biometricAvailable && globalState) {
+            sessionStorage.setItem(BIOMETRIC_ATTEMPTED_KEY, "true");
+            try {
+                await authenticate(
+                    "You must authenticate with PIN first",
+                    authOpts,
+                );
+                // Success — clear the flag (we won't reach /login at all)
+                // and run the shared post-auth routine.
+                sessionStorage.removeItem(BIOMETRIC_ATTEMPTED_KEY);
+                await continueAfterSuccessfulAuth(globalState);
+                return;
+            } catch (e) {
+                // Cancel/fail. Leave the flag set so /login skips its own
+                // biometric retry, then slide into /login for PIN entry.
+                console.warn("Biometric on splash failed", e);
+            }
+        }
+
+        await goto("/login");
         return;
     }
 
@@ -91,5 +141,4 @@ onMount(async () => {
     showDrawer={splashShowDrawer}
     oncreate={handleCreateDigitalSelf}
     onrestore={handleRestoreDigitalSelf}
-    oncontinue={returningUserTarget ? handleContinue : undefined}
 />


### PR DESCRIPTION
# Description of change
- Home greeting: trim redundant top padding, source display name from the self-binding doc (so KYC's legal name doesn't overwrite the handle the user typed), and re-enable the edit-name pencil with a bottom-sheet flow that re-issues the self-binding doc (create-new + delete-old, since evault-core has no update mutation).
- Login flow: fire biometric over the splash itself for returning users — success routes straight to /main with no /login flash; cancel/fail slides into /login with a sessionStorage flag so /login skips its own biometric retry. Shared post-auth chores extracted to $lib/utils/postLogin.ts.
- PIN screen: tapping the background refocuses the hidden PIN input to summon the soft keyboard without aiming for the dots. PinDots now exposes inputEl as $bindable.

## Issue Number
Closes #982 
Closes #981 

## Type of change

- New (a change which implements a new feature)
- Fix (a change which fixes an issue)

## How the change has been tested

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit their display name from the main screen.
  * Automatic biometric authentication for returning users on splash screen.

* **Bug Fixes**
  * Removed manual "Continue" button for returning users; streamlined authentication flow.
  * Improved PIN input focus handling for better keyboard interaction.

* **Refactor**
  * Consolidated post-authentication logic for consistent handling across flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->