### PR TITLE
Fix/reset pin logic

### DIFF
--- a/infrastructure/eid-wallet/src/routes/(app)/settings/pin/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/settings/pin/+page.svelte
@@ -55,6 +55,11 @@ async function advance() {
             submitting = false;
         }
     } else if (step === "new") {
+        if (newPin === currentPin) {
+            error = "Your new PIN must be different from your current PIN.";
+            newPin = "";
+            return;
+        }
         step = "repeat";
     } else {
         void submit();

--- a/infrastructure/eid-wallet/src/routes/(app)/settings/pin/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/settings/pin/+page.svelte
@@ -32,11 +32,28 @@ const stepTitle = $derived(
           : "Confirm your new PIN",
 );
 
-function advance() {
-    if (!canSubmit) return;
+async function advance() {
+    if (!canSubmit || submitting) return;
     error = null;
     if (step === "current") {
-        step = "new";
+        if (!globalState) return;
+        submitting = true;
+        try {
+            const ok =
+                await globalState.securityController.verifyPin(currentPin);
+            if (!ok) {
+                error = "That's not your current PIN. Try again.";
+                currentPin = "";
+                return;
+            }
+            step = "new";
+        } catch (err) {
+            console.error("Failed to verify current PIN:", err);
+            error = "Couldn't verify your current PIN. Try again.";
+            currentPin = "";
+        } finally {
+            submitting = false;
+        }
     } else if (step === "new") {
         step = "repeat";
     } else {
@@ -148,7 +165,7 @@ onMount(() => {
             class="w-full uppercase tracking-wide"
             disabled={!canSubmit || submitting}
             callback={advance}
-            blockingClick={step === "repeat"}
+            blockingClick={step !== "new"}
         >
             {step === "repeat" ? "Change PIN" : "Next"}
         </ButtonAction>


### PR DESCRIPTION
# Description of change

Two fixes to the Change-PIN flow in settings: the current-PIN step now verifies before advancing (previously the wrong PIN only surfaced after the user had typed all three screens), and the new PIN is rejected if it matches the current one.

## Issue Number

Closes #991 
Closes #992 

## Type of change

- Fix

## How the change has been tested

- Settings → Change PIN → enter wrong current PIN → inline error, dots cleared, stays on step 1.
- Settings → Change PIN → enter correct current PIN, then same value as new PIN → inline error, dots cleared, stays on step 2.
- Settings → Change PIN → enter correct current PIN, then a different new PIN, confirm → success bottom sheet.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PIN verification is now required when changing your PIN
  * Clear error messages display when verification fails
  * PIN field automatically resets on verification failure
  * Updated button interaction during PIN change workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->