### PR TITLE
fix(blabsy): recover composer when a Blab fails to send

### DIFF
--- a/platforms/blabsy/client/src/components/input/input.tsx
+++ b/platforms/blabsy/client/src/components/input/input.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef, useId } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import cn from 'clsx';
 import { toast } from 'react-hot-toast';
-import { addDoc, getDoc, serverTimestamp } from 'firebase/firestore';
+import { addDoc, serverTimestamp } from 'firebase/firestore';
 import { tweetsCollection } from '@lib/firebase/collections';
 import {
     manageReply,
@@ -96,14 +96,19 @@ export function Input({
 
             await sleep(500);
 
-            const [tweetRef] = await Promise.all([
-                addDoc(tweetsCollection, tweetData),
+            // Creating the Blab is the canonical "send" — its success defines
+            // success. addDoc returns a ref whose id is available immediately.
+            const tweetRef = await addDoc(tweetsCollection, tweetData);
+
+            // Counter/reply updates are secondary: a failure here must NOT report
+            // the send as failed, or the user retries and duplicates the Blab.
+            await Promise.all([
                 manageTotalTweets('increment', userId),
                 tweetData.images && manageTotalPhotos('increment', userId),
                 isReplying && manageReply('increment', parent?.id as string)
-            ]);
-
-            const { id: tweetId } = await getDoc(tweetRef);
+            ]).catch((error) =>
+                console.error('Blab sent, but a follow-up counter update failed:', error)
+            );
 
             if (!modal && !replyModal) {
                 discardTweet();
@@ -117,7 +122,7 @@ export function Input({
                     <span className='flex gap-2'>
                         Your Blab was sent
                         <Link
-                            href={`/tweet/${tweetId}`}
+                            href={`/tweet/${tweetRef.id}`}
                             className='custom-underline font-bold'
                         >
                             View

--- a/platforms/blabsy/client/src/components/input/input.tsx
+++ b/platforms/blabsy/client/src/components/input/input.tsx
@@ -81,50 +81,56 @@ export function Input({
 
         const userId = user?.id as string;
 
-        const tweetData: WithFieldValue<Omit<Tweet, 'id'>> = {
-            text: inputValue.trim() || null,
-            parent: isReplying && parent ? parent : null,
-            images: await uploadImages(userId, selectedImages),
-            userLikes: [],
-            createdBy: userId,
-            createdAt: serverTimestamp(),
-            updatedAt: null,
-            userReplies: 0,
-            userRetweets: []
-        };
+        try {
+            const tweetData: WithFieldValue<Omit<Tweet, 'id'>> = {
+                text: inputValue.trim() || null,
+                parent: isReplying && parent ? parent : null,
+                images: await uploadImages(userId, selectedImages),
+                userLikes: [],
+                createdBy: userId,
+                createdAt: serverTimestamp(),
+                updatedAt: null,
+                userReplies: 0,
+                userRetweets: []
+            };
 
-        await sleep(500);
+            await sleep(500);
 
-        const [tweetRef] = await Promise.all([
-            addDoc(tweetsCollection, tweetData),
-            manageTotalTweets('increment', userId),
-            tweetData.images && manageTotalPhotos('increment', userId),
-            isReplying && manageReply('increment', parent?.id as string)
-        ]);
+            const [tweetRef] = await Promise.all([
+                addDoc(tweetsCollection, tweetData),
+                manageTotalTweets('increment', userId),
+                tweetData.images && manageTotalPhotos('increment', userId),
+                isReplying && manageReply('increment', parent?.id as string)
+            ]);
 
-        const { id: tweetId } = await getDoc(tweetRef);
+            const { id: tweetId } = await getDoc(tweetRef);
 
-        if (!modal && !replyModal) {
-            discardTweet();
+            if (!modal && !replyModal) {
+                discardTweet();
+                setLoading(false);
+            }
+
+            if (closeModal) closeModal();
+
+            toast.success(
+                () => (
+                    <span className='flex gap-2'>
+                        Your Blab was sent
+                        <Link
+                            href={`/tweet/${tweetId}`}
+                            className='custom-underline font-bold'
+                        >
+                            View
+                        </Link>
+                    </span>
+                ),
+                { duration: 6000 }
+            );
+        } catch (error) {
+            console.error('Failed to send Blab:', error);
             setLoading(false);
+            toast.error('Failed to send your Blab. Please try again.');
         }
-
-        if (closeModal) closeModal();
-
-        toast.success(
-            () => (
-                <span className='flex gap-2'>
-                    Your Blab was sent
-                    <Link
-                        href={`/tweet/${tweetId}`}
-                        className='custom-underline font-bold'
-                    >
-                        View
-                    </Link>
-                </span>
-            ),
-            { duration: 6000 }
-        );
     };
 
     const handleImageUpload = (


### PR DESCRIPTION
# Description of change

`sendTweet` in the Blab composer set `loading = true` and only cleared it on the success path, with no error handling. When an image upload rejected (e.g. Firebase Storage quota exceeded, or a flaky mobile network), the promise rejected, the loading state was never reset, and the composer froze with no feedback — matching the reported "Blab stuck with 2+ images" behaviour (more images → higher chance one upload fails).

This wraps the send flow in `try/catch`: on failure it resets the loading state and shows an error toast, so the composer always recovers and the user can retry.

> Note: this fixes the **code** defect (silent freeze / no feedback). It does not change the fact that uploads themselves fail when the `w3ds-staging` Storage bucket quota is exhausted — that's an infra issue (plan/quota) tracked separately.

## Issue Number

closes #1025

## Type of change

- [x] **Fix** (a change which fixes an issue)

## How the change has been tested

Tested locally against the Firebase emulators (auth/firestore/storage), to work around the exhausted staging quota:

- **Happy path** — posting a Blab with 2 images succeeds and both images appear in the feed (no multi-image-specific defect: each image gets a unique id → unique storage path, uploaded in parallel).
- **Failure path** — temporarily denied Storage `create` in the rules to simulate the quota failure; confirmed the composer now shows an error toast ("Failed to send your Blab. Please try again.") and becomes usable again, instead of freezing silently.
- `pnpm exec tsc --noEmit` passes.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling for message sending operations, now providing explicit success confirmations with action links and clear failure notifications, replacing previous silent failures with transparent user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->