### PR TITLE
fix(blabsy): use dynamic viewport height so the chat composer isn't hidden by browser UI

### DIFF
--- a/platforms/blabsy/client/src/components/chat/chat.tsx
+++ b/platforms/blabsy/client/src/components/chat/chat.tsx
@@ -12,11 +12,11 @@ export function Chat(): JSX.Element {
         return (
             <main className='min-h-full w-full max-w-5xl pt-8 pb-8'>
                 {currentChat ? (
-                    <div className='h-[calc(100vh-6rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black'>
+                    <div className='h-[calc(100dvh-6rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black'>
                         <ChatWindow />
                     </div>
                 ) : (
-                    <div className='h-[calc(100vh-6rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black flex flex-col'>
+                    <div className='h-[calc(100dvh-6rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black flex flex-col'>
                         <ChatList />
                     </div>
                 )}
@@ -27,11 +27,11 @@ export function Chat(): JSX.Element {
     // On desktop, show both in grid layout
     return (
         <main className='min-h-full w-full max-w-5xl pt-8'>
-            <div className='grid h-[calc(100vh-4rem)] grid-cols-1 gap-4 md:grid-cols-[350px_1fr]'>
-                <div className='h-[calc(100vh-4rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black flex flex-col'>
+            <div className='grid h-[calc(100dvh-4rem)] grid-cols-1 gap-4 md:grid-cols-[350px_1fr]'>
+                <div className='h-[calc(100dvh-4rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black flex flex-col'>
                     <ChatList />
                 </div>
-                <div className='h-[calc(100vh-4rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black'>
+                <div className='h-[calc(100dvh-4rem)] rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-black'>
                     <ChatWindow />
                 </div>
             </div>


### PR DESCRIPTION
# Description of change

Switch the chat containers from 100vh to 100dvh (dynamic viewport height) so they track the actually-visible area. dvh equals vh when there is no browser chrome (PWA / desktop), so no regression there.

## Issue Number

Closes #1023 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested
Verified on a real Android device (Chrome): the composer now sits above the navigation bar and stays reachable with the keyboard open.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat window display on mobile and desktop by updating viewport height calculations to better accommodate browser UI elements and ensure consistent rendering across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->