### PR TITLE
[codex] Add task management ontologies

### DIFF
--- a/services/ontology/schemas/calendarEvent.json
+++ b/services/ontology/schemas/calendarEvent.json
@@ -8,10 +8,21 @@
       "type": "string",
       "description": "Event title"
     },
+    "id": { "type": "string", "description": "Application-level event identifier" },
+    "userEName": { "type": "string", "description": "eName of the user whose calendar contains the event" },
+    "provider": { "type": "string", "enum": ["google", "manual"] },
+    "externalEventId": { "type": "string" },
+    "calendarId": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "description": { "type": "string" },
+    "location": { "type": "string" },
     "color": {
       "type": "string",
       "description": "Event color (hex or named)"
     },
+    "textColor": { "type": "string" },
+    "providerColorId": { "type": ["string", "null"] },
+    "canEdit": { "type": "boolean" },
     "start": {
       "type": "string",
       "format": "date-time",
@@ -21,7 +32,16 @@
       "type": "string",
       "format": "date-time",
       "description": "Event end time (ISO 8601)"
-    }
+    },
+    "isAllDay": { "type": "boolean" },
+    "status": { "type": "string", "enum": ["confirmed", "tentative", "cancelled"] },
+    "attendees": { "type": "array", "items": { "type": "string" } },
+    "isTransparent": { "type": "boolean" },
+    "htmlLink": { "type": "string", "format": "uri" },
+    "sourceUpdatedAt": { "type": "string", "format": "date-time" },
+    "effectiveAcl": { "type": "array", "items": { "type": "string" } },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
   },
   "required": ["title", "start", "end"],
   "additionalProperties": false

--- a/services/ontology/schemas/company.json
+++ b/services/ontology/schemas/company.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f402",
+  "title": "Company",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string", "description": "Application-level company identifier" },
+    "eName": { "type": "string", "description": "eName of the company eVault" },
+    "groupManifestEnvelopeId": { "type": "string", "description": "MetaEnvelope ID of the canonical GroupManifest" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "eName", "groupManifestEnvelopeId", "createdAt", "updatedAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/companyProjectLink.json
+++ b/services/ontology/schemas/companyProjectLink.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f409",
+  "title": "CompanyProjectLink",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "companyId": { "type": "string" },
+    "companyEName": { "type": "string" },
+    "projectId": { "type": "string" },
+    "projectEName": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "companyId", "companyEName", "projectId", "projectEName", "canonicalOwnerEName", "createdAt", "updatedAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/contributorCapacity.json
+++ b/services/ontology/schemas/contributorCapacity.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f404",
+  "title": "ContributorCapacity",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string", "description": "Capacity record identifier" },
+    "personEName": { "type": "string", "description": "eName of the contributor" },
+    "weeklyW3dsHoursBudget": { "type": "number", "minimum": 0, "description": "Hours available per week" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "personEName", "weeklyW3dsHoursBudget", "createdAt", "updatedAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/membership.json
+++ b/services/ontology/schemas/membership.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f408",
+  "title": "Membership",
+  "oneOf": [
+    {
+      "title": "CanonicalMembership",
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "parentType": { "type": "string", "enum": ["company", "project"] },
+        "parentId": { "type": "string" },
+        "parentEName": { "type": "string" },
+        "memberEName": { "type": "string" },
+        "role": { "type": "string", "enum": ["participant", "admin"] },
+        "canonicalOwnerEName": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "parentType", "parentId", "parentEName", "memberEName", "role", "canonicalOwnerEName", "createdAt", "updatedAt"],
+      "additionalProperties": false
+    },
+    {
+      "title": "MembershipReference",
+      "type": "object",
+      "properties": {
+        "isReference": { "const": true },
+        "canonicalMembershipId": { "type": "string" },
+        "canonicalOwnerEName": { "type": "string" },
+        "canonicalEnvelopeId": { "type": "string" }
+      },
+      "required": ["isReference", "canonicalMembershipId", "canonicalOwnerEName", "canonicalEnvelopeId"],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/services/ontology/schemas/project.json
+++ b/services/ontology/schemas/project.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f403",
+  "title": "Project",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string", "description": "Application-level project identifier" },
+    "eName": { "type": "string", "description": "eName of the project eVault" },
+    "groupManifestEnvelopeId": { "type": "string", "description": "MetaEnvelope ID of the canonical GroupManifest" },
+    "grantsAccessRelatedProjectIds": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Projects whose members inherit access through this project"
+    },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "eName", "groupManifestEnvelopeId", "grantsAccessRelatedProjectIds", "createdAt", "updatedAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/task.json
+++ b/services/ontology/schemas/task.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f401",
+  "title": "Task",
+  "type": "object",
+  "definitions": {
+    "note": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "taskId": { "type": "string" },
+        "authorEName": { "type": "string" },
+        "content": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "taskId", "authorEName", "content", "createdAt"],
+      "additionalProperties": false
+    },
+    "attachment": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "taskId": { "type": "string" },
+        "fileName": { "type": "string" },
+        "url": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "taskId", "fileName", "url", "createdAt"],
+      "additionalProperties": false
+    },
+    "subtask": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "done": { "type": "boolean" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["id", "title", "done"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "id": { "type": "string", "description": "Logical task identifier" },
+    "canonicalOwnerEName": { "type": "string", "description": "eName of the eVault holding this canonical task" },
+    "homeProjectId": { "type": "string" },
+    "relatedProjectIds": { "type": "array", "items": { "type": "string" } },
+    "relatedCompanyIds": { "type": "array", "items": { "type": "string" } },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "createdBy": { "type": "string", "description": "Reporter eName" },
+    "assignees": { "type": "array", "items": { "type": "string" } },
+    "status": { "type": "string", "enum": ["planned", "in_progress", "done"] },
+    "priority": { "type": "integer", "enum": [0, 1, 2, 3] },
+    "progressPercent": { "type": "number", "minimum": 0, "maximum": 100 },
+    "estimatedHours": { "type": ["number", "null"], "minimum": 0 },
+    "deadline": { "type": ["string", "null"], "format": "date-time" },
+    "blockedByTaskIds": { "type": "array", "items": { "type": "string" } },
+    "blocksTaskIds": { "type": "array", "items": { "type": "string" } },
+    "notes": { "type": "array", "items": { "$ref": "#/definitions/note" } },
+    "attachments": { "type": "array", "items": { "$ref": "#/definitions/attachment" } },
+    "subtasks": { "type": "array", "items": { "$ref": "#/definitions/subtask" } },
+    "effectiveAcl": { "type": "array", "items": { "type": "string" } },
+    "manualAclAdds": { "type": "array", "items": { "type": "string" } },
+    "aiDraftSource": { "type": "string" },
+    "eVaultSyncStatus": { "type": "string", "enum": ["synced", "pending", "failed"] },
+    "eVaultSyncError": { "type": ["string", "null"] },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "closedAt": { "type": ["string", "null"], "format": "date-time" }
+  },
+  "required": [
+    "id",
+    "canonicalOwnerEName",
+    "homeProjectId",
+    "relatedProjectIds",
+    "relatedCompanyIds",
+    "title",
+    "description",
+    "createdBy",
+    "assignees",
+    "status",
+    "priority",
+    "progressPercent",
+    "estimatedHours",
+    "deadline",
+    "blockedByTaskIds",
+    "blocksTaskIds",
+    "notes",
+    "attachments",
+    "subtasks",
+    "effectiveAcl",
+    "manualAclAdds",
+    "createdAt",
+    "updatedAt",
+    "closedAt"
+  ],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/taskAttachment.json
+++ b/services/ontology/schemas/taskAttachment.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f407",
+  "title": "TaskAttachment",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "taskId": { "type": "string" },
+    "fileName": { "type": "string" },
+    "url": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "taskId", "fileName", "url", "canonicalOwnerEName", "createdAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/taskNote.json
+++ b/services/ontology/schemas/taskNote.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f406",
+  "title": "TaskNote",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "taskId": { "type": "string" },
+    "authorEName": { "type": "string" },
+    "content": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["id", "taskId", "authorEName", "content", "canonicalOwnerEName", "createdAt"],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/taskReference.json
+++ b/services/ontology/schemas/taskReference.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f405",
+  "title": "TaskReference",
+  "type": "object",
+  "properties": {
+    "isReference": { "const": true },
+    "canonicalTaskId": { "type": "string", "description": "Logical ID of the canonical task" },
+    "canonicalOwnerEName": { "type": "string", "description": "eName of the eVault holding the canonical task" },
+    "canonicalEnvelopeId": { "type": "string", "description": "MetaEnvelope ID of the canonical task" }
+  },
+  "required": ["isReference", "canonicalTaskId", "canonicalOwnerEName"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What changed

- adds W3DS schemas for Task, Company, Project, ContributorCapacity, TaskReference, TaskNote, TaskAttachment, Membership, and CompanyProjectLink
- models canonical memberships and user-vault membership references as two forms of the same Membership ontology
- extends the existing CalendarEvent schema with optional provider, ownership, access, presentation, and synchronization fields
- keeps the canonical CalendarEvent fields `title`, `start`, and `end` unchanged and required

## Why

80hours stores these MetaEnvelope types in W3DS eVaults, but their schema IDs were not yet published by the Ontology service. CalendarEvent data also needs richer optional metadata without introducing a duplicate calendar ontology.

## Compatibility

The CalendarEvent change is additive: existing payloads containing `title`, `start`, and `end` remain valid. No existing schema ID is replaced.

## Validation

- parsed every schema as JSON and checked schema ID uniqueness
- compiled all Ontology service schemas with AJV draft-07 in the service-compatible non-strict mode
- validated representative 80hours payloads for all nine new schemas, both Membership variants, and CalendarEvent using AJV with format validation
- started the Ontology service locally; it loaded 27 schemas and returned all nine new IDs through `/schemas` and `/schemas/:id`
