### PR TITLE
fix: fixed the inconsistent header issue in pictique.

### DIFF
--- a/platforms/pictique/client/src/lib/fragments/Header/Header.svelte
+++ b/platforms/pictique/client/src/lib/fragments/Header/Header.svelte
@@ -41,12 +41,36 @@
 
 	type Variant = 'primary' | 'secondary' | 'tertiary';
 
+	// Settings is a top-level sidebar destination on desktop, same as Feed or
+	// Search, but on mobile it's only reachable by drilling in from the
+	// Profile page header — so its root page needs the same 'primary' variant
+	// Feed uses on desktop, and 'secondary' (back button) on mobile. This is
+	// tracked as real state so the root `/settings` page renders through the
+	// exact same variant path as every other top-level page, rather than
+	// showing back-button markup that's merely hidden with CSS on desktop.
+	let isDesktop = $state(true);
+
+	$effect(() => {
+		const query = window.matchMedia('(min-width: 768px)');
+		isDesktop = query.matches;
+		const handleChange = (event: MediaQueryListEvent) => {
+			isDesktop = event.matches;
+		};
+		query.addEventListener('change', handleChange);
+		return () => query.removeEventListener('change', handleChange);
+	});
+
 	let variant = $derived.by((): Variant => {
 		if (route === `/messages/${page.params.id}` || route.includes('/post')) {
 			return 'secondary';
 		}
-		if (route.includes('profile')) {
-			return 'tertiary';
+		if (route === '/settings') {
+			return isDesktop ? 'primary' : 'secondary';
+		}
+		// Every page nested under Settings (notifications, account, etc.) is
+		// always a drill-down, on both mobile and desktop.
+		if (route.startsWith('/settings/')) {
+			return 'secondary';
 		}
 		return 'primary';
 	});

--- a/platforms/pictique/client/src/lib/fragments/Header/Header.svelte
+++ b/platforms/pictique/client/src/lib/fragments/Header/Header.svelte
@@ -48,7 +48,9 @@
 	// tracked as real state so the root `/settings` page renders through the
 	// exact same variant path as every other top-level page, rather than
 	// showing back-button markup that's merely hidden with CSS on desktop.
-	let isDesktop = $state(true);
+	let isDesktop = $state(
+		typeof window !== 'undefined' ? window.matchMedia('(min-width: 768px)').matches : true
+	);
 
 	$effect(() => {
 		const query = window.matchMedia('(min-width: 768px)');

--- a/platforms/pictique/client/src/routes/(protected)/settings/account/+page.svelte
+++ b/platforms/pictique/client/src/routes/(protected)/settings/account/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
 	onMount(() => {
-		goto('/settings/account/username', { replaceState: true });
+		goto(resolve('/settings/account/username'), { replaceState: true });
 	});
 </script>

--- a/platforms/pictique/client/src/routes/(protected)/settings/account/+page.svelte
+++ b/platforms/pictique/client/src/routes/(protected)/settings/account/+page.svelte
@@ -3,6 +3,6 @@
 	import { onMount } from 'svelte';
 
 	onMount(() => {
-		goto('/settings/account/username');
+		goto('/settings/account/username', { replaceState: true });
 	});
 </script>


### PR DESCRIPTION
# Description of change

A consistent rule applied across the app:

- Top-level pages reachable directly via the sidebar or bottom navbar → title-based header.
- Nested/drill-down pages (pages navigated to from within another page) → back-button header.

Concretely:

- Profile page → title-based header (it is a top-level nav destination).
- Settings page on mobile (opened from the Profile header) → back-button header.
- Notification Preferences page (opened from Settings) → back-button header.
- Edit Profile page (opened from Settings) → back-button header.

## Issue Number

Closes #1062 

## Type of change

- Update (a change which updates existing functionality)
- Fix (a change which fixes an issue)

## How the change has been tested

Manually.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header styling on the settings area to better match desktop and mobile layouts.
  * Settings subpages now consistently use a secondary header style when drilling into nested routes.
  * Updated the settings account redirect so it no longer adds an extra browser history entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->