### PR TITLE
fix: toast now disappears on mobile when clicked on view button.

### DIFF
--- a/platforms/blabsy/client/src/components/input/input.tsx
+++ b/platforms/blabsy/client/src/components/input/input.tsx
@@ -117,13 +117,14 @@ export function Input({
 
             if (closeModal) closeModal();
 
-            toast.success(
+            const toastId = toast.success(
                 () => (
                     <span className='flex gap-2'>
                         Your Blab was sent
                         <Link
                             href={`/tweet/${tweetRef.id}`}
                             className='custom-underline font-bold'
+                            onClick={() => toast.dismiss(toastId)}
                         >
                             View
                         </Link>


### PR DESCRIPTION
# Description of change

Toast fixed for not dismissing when view button clicked on mobile.

## Issue Number

Closes #1046 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

Manually.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the success notification shown after sending a Blab so the **View** link now closes that specific message when clicked.
  * Simplified the toast behavior for this confirmation message, keeping the experience cleaner and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->