### PR TITLE
fix: fixed the race condition when opening app through deeplink.

### DIFF
--- a/infrastructure/eid-wallet/src/routes/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/+page.svelte
@@ -93,6 +93,19 @@ onMount(async () => {
             return;
         }
 
+        // A third-party login deep link opened the app. The root layout has
+        // already stored it and redirected to /login, which runs its own
+        // biometric prompt. If we ALSO prompt here, two native authenticate()
+        // calls race on a cold start — the collision, plus a duplicate
+        // post-auth routine consuming the pending deep link, leaves the user
+        // on /main with the consent screen never shown. Defer to /login as the
+        // single authenticator. The layout writes pendingDeepLink synchronously
+        // and early, so it's reliably visible by the time we reach here.
+        if (sessionStorage.getItem("pendingDeepLink")) {
+            await goto("/login");
+            return;
+        }
+
         // Fire biometric over the splash itself so the prompt isn't competing
         // with the /login slide-in. On success we run the post-auth chores
         // and route straight to /main (no /login flash). On cancel/fail we


### PR DESCRIPTION
# Description of change

Fixed the race condition when loggin in app through deeplink.

## Issue Number

Closes #1048 

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested
Manually.
## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the splash screen flow to avoid overlapping authentication prompts when a pending deep link is present.
  * Added a direct redirect to the login screen for users arriving through a deep link, resulting in a smoother and more reliable sign-in experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->