### PR TITLE
[codex] Support task drafts and canonical relocation

### DIFF
--- a/services/ontology/schemas/task.json
+++ b/services/ontology/schemas/task.json
@@ -52,6 +52,11 @@
     "createdBy": { "type": "string", "description": "Reporter eName" },
     "assignees": { "type": "array", "items": { "type": "string" } },
     "status": { "type": "string", "enum": ["planned", "in_progress", "done"] },
+    "intakeStatus": {
+      "type": "string",
+      "enum": ["draft", "ready"],
+      "description": "Cross-application intake state. Missing values are treated as legacy ready tasks unless required task fields are incomplete."
+    },
     "priority": { "type": "integer", "enum": [0, 1, 2, 3] },
     "progressPercent": { "type": "number", "minimum": 0, "maximum": 100 },
     "estimatedHours": { "type": ["number", "null"], "minimum": 0 },
@@ -73,7 +78,6 @@
   "required": [
     "id",
     "canonicalOwnerEName",
-    "homeProjectId",
     "relatedProjectIds",
     "relatedCompanyIds",
     "title",

--- a/services/ontology/schemas/taskReference.json
+++ b/services/ontology/schemas/taskReference.json
@@ -7,7 +7,13 @@
     "isReference": { "const": true },
     "canonicalTaskId": { "type": "string", "description": "Logical ID of the canonical task" },
     "canonicalOwnerEName": { "type": "string", "description": "eName of the eVault holding the canonical task" },
-    "canonicalEnvelopeId": { "type": "string", "description": "MetaEnvelope ID of the canonical task" }
+    "canonicalEnvelopeId": { "type": "string", "description": "MetaEnvelope ID of the current canonical task" },
+    "referenceType": {
+      "type": "string",
+      "enum": ["canonical-relocation"],
+      "description": "Present when a former canonical Task envelope redirects to a relocated canonical envelope"
+    },
+    "relocatedAt": { "type": "string", "format": "date-time" }
   },
   "required": ["isReference", "canonicalTaskId", "canonicalOwnerEName"],
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- add optional `intakeStatus: draft | ready` to the Task ontology
- allow external drafts without `homeProjectId`; empty `assignees` remains valid
- extend TaskReference with optional `canonicalEnvelopeId`, `referenceType`, and `relocatedAt` for canonical relocation

## Interoperability semantics
- each MetaEnvelope still has exactly one ACL; no `originAcl` or secondary readable ACL is introduced
- a relocated former canonical envelope can remain as a content-free TaskReference under its existing envelope ACL
- consumers follow `canonicalEnvelopeId` to the current canonical Task and enforce that canonical envelope ACL independently
- all new fields are optional so legacy Tasks and TaskReferences remain valid

## Validation
- JSON parsing and `git diff --check` pass
- AJV draft-07 validates an external draft without project/assignees
- AJV draft-07 validates a canonical-relocation TaskReference
- 80hours `npm run check` and `npm run build` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task intake statuses: `draft` and `ready`.
  * Added metadata for relocated canonical task references, including relocation type, timestamp, and canonical envelope details.

* **Bug Fixes**
  * Tasks no longer require a home project identifier to be valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->