### PR TITLE
fix: retry vault read on resume-window IPC failure to prevent false sign-out

### DIFF
--- a/infrastructure/eid-wallet/package.json
+++ b/infrastructure/eid-wallet/package.json
@@ -14,6 +14,7 @@
         "lint": "npx @biomejs/biome lint --write ./src",
         "check-lint": "npx @biomejs/biome lint ./src",
         "tauri": "tauri",
+        "test": "vitest run",
         "storybook": "svelte-kit sync && storybook dev -p 6006",
         "build-storybook": "storybook build",
         "build:apk": "npm run tauri android build -- --apk --target aarch64 --target armv7",

--- a/infrastructure/eid-wallet/src/lib/global/controllers/evault.spec.ts
+++ b/infrastructure/eid-wallet/src/lib/global/controllers/evault.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// evault.ts imports these at runtime; mock them so the module loads in a plain
+// Node test env without pulling Tauri / wallet-sdk internals.
+vi.mock("wallet-sdk", () => ({ syncPublicKeyToEvault: vi.fn() }));
+vi.mock("../../services/NotificationService", () => ({
+    default: {
+        getInstance: () => ({ registerDevice: vi.fn(async () => true) }),
+    },
+}));
+
+import { VaultController } from "./evault";
+
+const VAULT = { ename: "user@w3id.example", uri: "https://evault.example" };
+
+/** Build a VaultController whose only exercised dependency is `store.get`. */
+function makeController(get: (key: string) => Promise<unknown>) {
+    const store = { get } as unknown as ConstructorParameters<
+        typeof VaultController
+    >[0];
+    const userController = {
+        user: Promise.resolve(undefined),
+    } as unknown as ConstructorParameters<typeof VaultController>[1];
+    return new VaultController(store, userController);
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("VaultController.vault — #readVaultResilient retry behavior", () => {
+    it("returns immediately for a resolved undefined (genuine logout), no retry", async () => {
+        const get = vi.fn(async () => undefined);
+        const vc = makeController(get);
+
+        await expect(vc.vault).resolves.toBeUndefined();
+        expect(get).toHaveBeenCalledTimes(1); // no retry when the key is simply absent
+    });
+
+    it("retries thrown store errors up to maxAttempts, then returns undefined without throwing", async () => {
+        vi.useFakeTimers();
+        const get = vi.fn(async () => {
+            throw new Error(
+                "Fetch API cannot load ipc://localhost/plugin:store|get",
+            );
+        });
+        const vc = makeController(get);
+
+        const result = vc.vault;
+        await vi.runAllTimersAsync(); // skip the 200ms backoffs
+
+        await expect(result).resolves.toBeUndefined();
+        expect(get).toHaveBeenCalledTimes(10); // maxAttempts
+    });
+
+    it("recovers the vault when the store IPC comes back mid-retry", async () => {
+        vi.useFakeTimers();
+        let calls = 0;
+        const get = vi.fn(async () => {
+            if (calls++ < 6) throw new Error("IPC custom protocol failed");
+            return VAULT;
+        });
+        const vc = makeController(get);
+
+        const result = vc.vault;
+        await vi.runAllTimersAsync();
+
+        await expect(result).resolves.toEqual(VAULT);
+        expect(get).toHaveBeenCalledTimes(7);
+    });
+
+    it("coalesces concurrent reads into a single in-flight store read", async () => {
+        const get = vi.fn(async () => VAULT);
+        const vc = makeController(get);
+
+        const [a, b] = await Promise.all([vc.vault, vc.vault]);
+
+        expect(a).toEqual(VAULT);
+        expect(b).toEqual(VAULT);
+        expect(get).toHaveBeenCalledTimes(1); // both callers shared one read
+
+        // ...and a later, independent access performs a fresh read.
+        await vc.vault;
+        expect(get).toHaveBeenCalledTimes(2);
+    });
+});

--- a/infrastructure/eid-wallet/src/lib/global/controllers/evault.ts
+++ b/infrastructure/eid-wallet/src/lib/global/controllers/evault.ts
@@ -580,29 +580,32 @@ export class VaultController {
         }
     }
 
+    #vaultReadInFlight: Promise<Record<string, string> | undefined> | null =
+        null;
+
     get vault() {
-        return this.#readVaultResilient();
+        // Coalesce concurrent reads so the resume window doesn't spin one
+        // retry loop per caller; cleared on settle so later reads are fresh.
+        if (this.#vaultReadInFlight) return this.#vaultReadInFlight;
+        const read = this.#readVaultResilient().finally(() => {
+            this.#vaultReadInFlight = null;
+        });
+        this.#vaultReadInFlight = read;
+        return read;
     }
 
     /**
-     * Read the persisted vault, distinguishing "no vault" (genuinely logged out
-     * → resolves `undefined` with no throw) from a transient store IPC failure.
+     * Read the persisted vault, distinguishing "no vault" (resolved `undefined`
+     * → genuine logout) from a transient store IPC failure (a throw).
      *
-     * On iOS the `ipc://localhost` custom protocol is briefly torn down right
-     * after the app resumes from background (the WebView logs "IPC custom
-     * protocol failed, Tauri will now use the postMessage interface instead" and
-     * "Fetch API cannot load ipc://localhost/plugin:store|get due to access
-     * control checks"). During that window every `invoke` — including
-     * `plugin:store|get` — throws. The old getter swallowed that throw into
-     * `undefined`, which is indistinguishable from "never logged in", so route
-     * guards (deep-link handler, scan-qr, the app guard) redirected the user to
-     * /login: the intermittent unexpected sign-out.
+     * On iOS the `ipc://localhost` protocol is briefly torn down after the app
+     * resumes from background, so `plugin:store|get` throws. The old getter
+     * swallowed that into `undefined` — indistinguishable from "never logged
+     * in" — so route guards redirected to /login: the intermittent sign-out.
      *
-     * We retry the read on THROW so the resume window passes before we ever
-     * report "no vault". A genuine logout is a resolved-`undefined`, not a
-     * throw, so it returns immediately with no retry penalty. The getter still
-     * never throws and still returns `Record | undefined` — callers are
-     * unchanged.
+     * We retry on THROW so the resume window passes before reporting "no vault".
+     * A genuine logout resolves `undefined` (no throw) and returns immediately.
+     * Still never throws, still returns `Record | undefined` — callers unchanged.
      */
     async #readVaultResilient(): Promise<Record<string, string> | undefined> {
         const maxAttempts = 10;

--- a/infrastructure/eid-wallet/src/lib/global/controllers/evault.ts
+++ b/infrastructure/eid-wallet/src/lib/global/controllers/evault.ts
@@ -581,18 +581,54 @@ export class VaultController {
     }
 
     get vault() {
-        return this.#store
-            .get<Record<string, string>>("vault")
-            .then((vault) => {
-                if (!vault) {
+        return this.#readVaultResilient();
+    }
+
+    /**
+     * Read the persisted vault, distinguishing "no vault" (genuinely logged out
+     * → resolves `undefined` with no throw) from a transient store IPC failure.
+     *
+     * On iOS the `ipc://localhost` custom protocol is briefly torn down right
+     * after the app resumes from background (the WebView logs "IPC custom
+     * protocol failed, Tauri will now use the postMessage interface instead" and
+     * "Fetch API cannot load ipc://localhost/plugin:store|get due to access
+     * control checks"). During that window every `invoke` — including
+     * `plugin:store|get` — throws. The old getter swallowed that throw into
+     * `undefined`, which is indistinguishable from "never logged in", so route
+     * guards (deep-link handler, scan-qr, the app guard) redirected the user to
+     * /login: the intermittent unexpected sign-out.
+     *
+     * We retry the read on THROW so the resume window passes before we ever
+     * report "no vault". A genuine logout is a resolved-`undefined`, not a
+     * throw, so it returns immediately with no retry penalty. The getter still
+     * never throws and still returns `Record | undefined` — callers are
+     * unchanged.
+     */
+    async #readVaultResilient(): Promise<Record<string, string> | undefined> {
+        const maxAttempts = 10;
+        const retryDelayMs = 200; // ~2s total budget covers the IPC-dead window
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                const vault =
+                    await this.#store.get<Record<string, string>>("vault");
+                return vault ?? undefined;
+            } catch (error) {
+                if (attempt === maxAttempts) {
+                    console.error(
+                        "Failed to get vault after retries (store IPC unavailable):",
+                        error,
+                    );
                     return undefined;
                 }
-                return vault;
-            })
-            .catch((error) => {
-                console.error("Failed to get vault:", error);
-                return undefined;
-            });
+                console.warn(
+                    `[VaultController] vault read failed (attempt ${attempt}/${maxAttempts}), store IPC likely re-initializing after resume — retrying...`,
+                );
+                await new Promise((resolve) =>
+                    setTimeout(resolve, retryDelayMs),
+                );
+            }
+        }
+        return undefined;
     }
 
     // Getters for internal properties

--- a/infrastructure/eid-wallet/src/test/env-static-public.ts
+++ b/infrastructure/eid-wallet/src/test/env-static-public.ts
@@ -1,0 +1,6 @@
+// Test stub for SvelteKit's `$env/static/public` (aliased in vitest.config.ts).
+// Real values are injected by SvelteKit at build time; tests only need the
+// symbols to exist so modules that import them can load.
+export const PUBLIC_EID_WALLET_TOKEN = "";
+export const PUBLIC_PROVISIONER_URL = "";
+export const PUBLIC_REGISTRY_URL = "";

--- a/infrastructure/eid-wallet/vitest.config.ts
+++ b/infrastructure/eid-wallet/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Dedicated, isolated test config — intentionally does NOT load the app's
+// Svelte/Tauri/Tailwind plugins. Unit tests here run in a plain Node
+// environment and stub the few runtime-only imports (see `$env` alias below;
+// heavier deps are mocked per-spec with `vi.mock`).
+export default defineConfig({
+    resolve: {
+        alias: {
+            "$env/static/public": fileURLToPath(
+                new URL("./src/test/env-static-public.ts", import.meta.url),
+            ),
+        },
+    },
+    test: {
+        environment: "node",
+        include: ["src/**/*.spec.ts"],
+    },
+});


### PR DESCRIPTION
# Description of change

Fix an intermittent, unexpected sign-out in the eID Wallet: on iOS the `ipc://localhost` custom protocol is briefly torn down when the app resumes from background, so `plugin:store|get` throws — the vault getter swallowed that into `undefined` (looks like "logged out") and route guards redirected the user to `/login`. The getter now retries the read across the resume window instead of reporting a false logout.

No env/config/infra changes.

## Issue Number

Closes #1084

## Type of change

- Fix (a change which fixes an issue)

## How the change has been tested

- **Root cause confirmed on a physical iPhone:** backgrounding then resuming the app reproduces the exact console signature — `IPC custom protocol failed, Tauri will now use the postMessage interface instead – TypeError: Load failed` and `Fetch API cannot load ipc://localhost/plugin%3Astore%7Cget due to access control checks` — with the store `get` throwing inside the `vault` getter.
- **Fix logic verified in isolation:** a standalone harness mirroring `#readVaultResilient` asserts the three invariants — genuine logout → `undefined` immediately (no retry penalty); one transient resume-window throw → recovers the vault (stays logged in); persistent failure → `undefined`, never throws or hangs.
- **Lint:** `biome check` passes on the changed file.
- **Known limitation:** the anti-sign-out effect is **not observable under `tauri ios dev`** — dev-mode resume reloads the WebView (Vite reconnect), which independently masks the sign-out and preempts the retry loop. Real-runtime confirmation requires a release build (no Vite reload).

## Design decisions

- **Fixed at the single read point** (`get vault()`), not per-guard: one change covers the app guard, the deep-link handler and scan-qr, and leaves all ~15 callers untouched.
- **Retry on *throw* only, not on empty:** a genuine logout is a resolved-`undefined` (no throw) and returns immediately, so real logouts stay instant; the ~2s retry budget (10 × 200ms) is spent only during an actual IPC-dead window.
- **Getter contract preserved:** still returns `Record | undefined` and never throws, so no caller changes were needed.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault loading reliability during app resume when storage access is temporarily unavailable.
  * Added resilient, retry-based handling for transient storage read failures, distinguishing “no vault” from actual errors.
  * Coalesced simultaneous vault requests so multiple callers share a single in-flight read, with graceful fallback when reads ultimately fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->