### PR TITLE
Fix/eid wallet binding data loading

### DIFF
--- a/infrastructure/eid-wallet/package.json
+++ b/infrastructure/eid-wallet/package.json
@@ -14,7 +14,7 @@
         "lint": "npx @biomejs/biome lint --write ./src",
         "check-lint": "npx @biomejs/biome lint ./src",
         "tauri": "tauri",
-        "test": "vitest run",
+        "test": "vitest run --project eid-wallet",
         "storybook": "svelte-kit sync && storybook dev -p 6006",
         "build-storybook": "storybook build",
         "build:apk": "npm run tauri android build -- --apk --target aarch64 --target armv7",

--- a/infrastructure/eid-wallet/src/lib/utils/personalBinding.spec.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/personalBinding.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadPersonalBindings } from "./personalBinding";
+
+const GQL_URL = "http://vault.test:4000/graphql";
+const ENAME = "@ada-0000-0000";
+
+type StubResponse = {
+    ok: boolean;
+    status?: number;
+    json: () => Promise<unknown>;
+};
+
+function docs(edges: unknown[]): StubResponse {
+    return {
+        ok: true,
+        json: async () => ({ data: { bindingDocuments: { edges } } }),
+    };
+}
+
+const PHOTO_EDGES = [{ node: { id: "photo-1", parsed: null } }];
+// pickLatestEdge orders by signatures[0].timestamp and ignores anything without
+// one, so these fixtures must carry a signature to be seen at all.
+const PARAM_EDGES = [
+    {
+        node: {
+            id: "param-1",
+            parsed: {
+                type: "personal_parameters",
+                data: { text: "5'9\", brown eyes" },
+                signatures: [{ timestamp: "2026-07-15T10:00:00.000Z" }],
+            },
+        },
+    },
+];
+const SECURITY_EDGES = [
+    {
+        node: {
+            id: "sec-1",
+            parsed: {
+                type: "security_question",
+                data: { question: "First pet?" },
+                signatures: [{ timestamp: "2026-07-15T10:00:00.000Z" }],
+            },
+        },
+    },
+];
+
+/** Route each stubbed request by the `type` variable the caller sent. */
+function stubVault(byType: (type: string) => StubResponse) {
+    const mock = vi.fn(async (_url: string, init: { body: string }) => {
+        const body = JSON.parse(init.body) as {
+            variables?: { type?: string };
+        };
+        return byType(body.variables?.type ?? "");
+    });
+    vi.stubGlobal("fetch", mock);
+    return mock;
+}
+
+const allGood = (type: string): StubResponse => {
+    if (type === "photograph") return docs(PHOTO_EDGES);
+    if (type === "personal_parameters") return docs(PARAM_EDGES);
+    return docs(SECURITY_EDGES);
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("loadPersonalBindings — count-only path (home screen)", () => {
+    it("returns every mark when all queries succeed", async () => {
+        stubVault(allGood);
+
+        const loaded = await loadPersonalBindings(GQL_URL, ENAME, {
+            skipPhotoBlobs: true,
+        });
+
+        expect(loaded.photographs).toHaveLength(1);
+        expect(loaded.parameters?.text).toBe("5'9\", brown eyes");
+        expect(loaded.securityQuestion?.question).toBe("First pet?");
+    });
+
+    // The #1086 regression: these used to resolve with an empty result, which
+    // the caller then wrote over the store as a full replace — wiping marks the
+    // user still had. Rejecting is what lets the caller keep the last good state.
+    it("rejects when a query fails at the HTTP level, instead of reporting no marks", async () => {
+        stubVault((type) =>
+            type === "photograph"
+                ? { ok: false, status: 503, json: async () => ({}) }
+                : allGood(type),
+        );
+
+        await expect(
+            loadPersonalBindings(GQL_URL, ENAME, { skipPhotoBlobs: true }),
+        ).rejects.toThrow(/503/);
+    });
+
+    it("rejects on a GraphQL-level error (HTTP 200 + errors)", async () => {
+        stubVault((type) =>
+            type === "security_question"
+                ? {
+                      ok: true,
+                      json: async () => ({
+                          errors: [{ message: "token expired" }],
+                          data: null,
+                      }),
+                  }
+                : allGood(type),
+        );
+
+        await expect(
+            loadPersonalBindings(GQL_URL, ENAME, { skipPhotoBlobs: true }),
+        ).rejects.toThrow(/token expired/);
+    });
+
+    it("still reports genuinely absent marks as empty, not as a failure", async () => {
+        stubVault(() => docs([]));
+
+        const loaded = await loadPersonalBindings(GQL_URL, ENAME, {
+            skipPhotoBlobs: true,
+        });
+
+        expect(loaded.photographs).toHaveLength(0);
+        expect(loaded.parameters).toBeNull();
+        expect(loaded.securityQuestion).toBeNull();
+    });
+});

--- a/infrastructure/eid-wallet/src/lib/utils/personalBinding.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/personalBinding.ts
@@ -466,52 +466,30 @@ async function _loadPersonalBindingsCountOnly(
     ownerEname: string,
 ): Promise<LoadedPersonalBindings> {
     type Resp = { bindingDocuments: { edges: BindingDocEdge[] } };
-    const empty: Resp = { bindingDocuments: { edges: [] } };
 
-    const [photosResult, paramsResult, securityResult] =
-        await Promise.allSettled([
-            vaultGqlRequest<Resp>(
-                gqlUrl,
-                ownerEname,
-                PERSONAL_PHOTO_IDS_QUERY,
-                { type: "photograph" },
-            ),
-            vaultGqlRequest<Resp>(
-                gqlUrl,
-                ownerEname,
-                PERSONAL_BINDING_BY_TYPE_QUERY,
-                { type: "personal_parameters" },
-            ),
-            vaultGqlRequest<Resp>(
-                gqlUrl,
-                ownerEname,
-                PERSONAL_BINDING_BY_TYPE_QUERY,
-                { type: "security_question" },
-            ),
-        ]);
-
-    if (photosResult.status === "rejected")
-        console.warn(
-            "[personalBinding] photograph count failed:",
-            photosResult.reason,
-        );
-    if (paramsResult.status === "rejected")
-        console.warn(
-            "[personalBinding] personal_parameters fetch failed:",
-            paramsResult.reason,
-        );
-    if (securityResult.status === "rejected")
-        console.warn(
-            "[personalBinding] security_question fetch failed:",
-            securityResult.reason,
-        );
-
-    const photosResp =
-        photosResult.status === "fulfilled" ? photosResult.value : empty;
-    const paramsResp =
-        paramsResult.status === "fulfilled" ? paramsResult.value : empty;
-    const securityResp =
-        securityResult.status === "fulfilled" ? securityResult.value : empty;
+    // Promise.all, not allSettled: callers feed this straight into a full-store
+    // replace, so substituting an empty result for a failed query is not
+    // graceful degradation — it erases marks the user still has. A partial
+    // result is no safer than none, since the replace overwrites either way.
+    // Rejecting lets the caller keep the last good state. Matches the sibling
+    // path in loadPersonalBindings above.
+    const [photosResp, paramsResp, securityResp] = await Promise.all([
+        vaultGqlRequest<Resp>(gqlUrl, ownerEname, PERSONAL_PHOTO_IDS_QUERY, {
+            type: "photograph",
+        }),
+        vaultGqlRequest<Resp>(
+            gqlUrl,
+            ownerEname,
+            PERSONAL_BINDING_BY_TYPE_QUERY,
+            { type: "personal_parameters" },
+        ),
+        vaultGqlRequest<Resp>(
+            gqlUrl,
+            ownerEname,
+            PERSONAL_BINDING_BY_TYPE_QUERY,
+            { type: "security_question" },
+        ),
+    ]);
 
     const photographs: LoadedPhotograph[] = (
         photosResp.bindingDocuments?.edges ?? []

--- a/infrastructure/eid-wallet/src/lib/utils/socialBinding.spec.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/socialBinding.spec.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearVaultUriCache, resolveVaultUri } from "./socialBinding";
+
+const ENAME = "@ada-0000-0000";
+const OTHER = "@grace-1111-1111";
+const VAULT_URI = "http://vault.test:4000";
+const EXPECTED = "http://vault.test:4000/graphql";
+
+/** Registry responds with a vault URI; counts how often it was actually hit. */
+function stubRegistry(uri = VAULT_URI) {
+    const fetchMock = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ uri }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
+
+beforeEach(() => {
+    clearVaultUriCache();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("resolveVaultUri — registry lookup memoisation", () => {
+    it("hits the registry once for repeated sequential lookups", async () => {
+        const fetchMock = stubRegistry();
+
+        expect(await resolveVaultUri(ENAME)).toBe(EXPECTED);
+        expect(await resolveVaultUri(ENAME)).toBe(EXPECTED);
+        expect(await resolveVaultUri(ENAME)).toBe(EXPECTED);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("coalesces concurrent lookups of the same eName into one request", async () => {
+        const fetchMock = stubRegistry();
+
+        // This is the real shape of the bug: the binding reconcile and the name
+        // lookup resolve the same counterparty at the same time, via Promise.all.
+        const results = await Promise.all([
+            resolveVaultUri(ENAME),
+            resolveVaultUri(ENAME),
+            resolveVaultUri(ENAME),
+            resolveVaultUri(ENAME),
+        ]);
+
+        expect(results).toEqual([EXPECTED, EXPECTED, EXPECTED, EXPECTED]);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats a bare eName and an @-prefixed one as the same cache entry", async () => {
+        const fetchMock = stubRegistry();
+
+        await resolveVaultUri("ada-0000-0000");
+        await resolveVaultUri("@ada-0000-0000");
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps distinct eNames independent", async () => {
+        const fetchMock = stubRegistry();
+
+        await resolveVaultUri(ENAME);
+        await resolveVaultUri(OTHER);
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache failures — a later lookup retries the registry", async () => {
+        const failing = vi.fn(async () => ({ ok: false, status: 503 }));
+        vi.stubGlobal("fetch", failing);
+
+        await expect(resolveVaultUri(ENAME)).rejects.toThrow(
+            /could not resolve/i,
+        );
+        await expect(resolveVaultUri(ENAME)).rejects.toThrow(
+            /could not resolve/i,
+        );
+
+        expect(failing).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearVaultUriCache forces the next lookup back to the registry", async () => {
+        const fetchMock = stubRegistry();
+
+        await resolveVaultUri(ENAME);
+        clearVaultUriCache();
+        await resolveVaultUri(ENAME);
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/infrastructure/eid-wallet/src/lib/utils/socialBinding.ts
+++ b/infrastructure/eid-wallet/src/lib/utils/socialBinding.ts
@@ -29,11 +29,17 @@ export interface BindingDocEdge {
 // Registry resolution
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve an eName to its eVault GraphQL endpoint via the registry.
- */
-export async function resolveVaultUri(ename: string): Promise<string> {
-    const normalized = ename.startsWith("@") ? ename : `@${ename}`;
+const VAULT_URI_TTL_MS = 5 * 60_000;
+const vaultUriCache = new Map<string, { uri: string; at: number }>();
+const vaultUriInFlight = new Map<string, Promise<string>>();
+
+/** Drop the memoised registry lookups (sign-out, tests). */
+export function clearVaultUriCache(): void {
+    vaultUriCache.clear();
+    vaultUriInFlight.clear();
+}
+
+async function fetchVaultUri(normalized: string): Promise<string> {
     const url = new URL(
         `resolve?w3id=${encodeURIComponent(normalized)}`,
         PUBLIC_REGISTRY_URL,
@@ -50,6 +56,37 @@ export async function resolveVaultUri(ename: string): Promise<string> {
     return base.endsWith("/graphql")
         ? base
         : new URL("/graphql", base).toString();
+}
+
+/**
+ * Resolve an eName to its eVault GraphQL endpoint via the registry.
+ *
+ * Memoised: an eName→URI mapping only changes when a vault is re-provisioned,
+ * but several layers resolve the same counterparty independently on one screen
+ * load (the binding reconcile and the name lookup, for a start), so the same
+ * round trip was being paid 3-4× per contact. Concurrent callers share one
+ * in-flight request; failures are not cached.
+ */
+export async function resolveVaultUri(ename: string): Promise<string> {
+    const normalized = ename.startsWith("@") ? ename : `@${ename}`;
+
+    const cached = vaultUriCache.get(normalized);
+    if (cached && Date.now() - cached.at < VAULT_URI_TTL_MS) return cached.uri;
+
+    const pending = vaultUriInFlight.get(normalized);
+    if (pending) return pending;
+
+    const request = fetchVaultUri(normalized)
+        .then((uri) => {
+            vaultUriCache.set(normalized, { uri, at: Date.now() });
+            return uri;
+        })
+        .finally(() => {
+            vaultUriInFlight.delete(normalized);
+        });
+
+    vaultUriInFlight.set(normalized, request);
+    return request;
 }
 
 // ---------------------------------------------------------------------------

--- a/infrastructure/eid-wallet/src/routes/(app)/cache.ts
+++ b/infrastructure/eid-wallet/src/routes/(app)/cache.ts
@@ -1,0 +1,28 @@
+/**
+ * Registry of the module-scope render caches that survive logout.
+ *
+ * Pages stash their last-known values at module scope so re-entering paints
+ * instantly instead of flashing a spinner. That state outlives logout:
+ * `performLogout` leaves with `goto("/")`, a client-side navigation, and
+ * SvelteKit never re-evaluates a module on client-side nav. So without an
+ * explicit reset, the next user to onboard on this device is shown the
+ * previous user's data. Same hazard `clearAllCachedPhotos` exists for.
+ *
+ * A page registers its own reset from `<script module>`, which keeps the cache
+ * colocated with the code that fills it. A page that was never visited never
+ * registered — and has nothing cached to leak.
+ */
+const resets = new Set<() => void>();
+
+/** Register a page's cache reset. Call from `<script module>`. */
+export function registerPageCacheReset(reset: () => void): void {
+    resets.add(reset);
+}
+
+/**
+ * Wipe every registered page cache. Call on logout to prevent cross-user data
+ * leaks.
+ */
+export function clearAllPageCaches(): void {
+    for (const reset of resets) reset();
+}

--- a/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
@@ -27,7 +27,6 @@ let hasEverLoaded = false;
 
 <script lang="ts">
 import { goto } from "$app/navigation";
-import { PUBLIC_EID_WALLET_TOKEN } from "$env/static/public";
 import type { GlobalState } from "$lib/global";
 import {
     getUnreadCount,
@@ -42,6 +41,7 @@ import {
     fetchNameFromVault,
     fetchReconciledSocialBindings,
     resolveVaultUri,
+    vaultGqlRequest,
 } from "$lib/utils";
 import { getCanonicalBindingDocString } from "$lib/utils/bindingDocHash";
 import { replaceAll as replaceAllPersonal } from "$lib/stores/personalBinding";
@@ -218,6 +218,12 @@ async function handleKycUpgraded() {
 // LegalIdDoc shape the accordion expects. The doc's `data` may carry fields
 // directly or only a Didit `reference` — we fall back to userController.user
 // (populated by the KYC upgrade) when the binding doc is sparse.
+const TYPED_BINDING_DOCS_QUERY = `query($type: BindingDocumentType!) {
+    bindingDocuments(type: $type, first: 50) {
+        edges { node { id parsed } }
+    }
+}`;
+
 async function loadBindingDocuments(): Promise<void> {
     if (!globalState) return;
     const vault = await globalState.vaultController.vault;
@@ -228,40 +234,37 @@ async function loadBindingDocuments(): Promise<void> {
         : `@${vault.ename}`;
     const gqlUrl = new URL("/graphql", vault.uri).toString();
 
-    const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-        "X-ENAME": enameHeader,
-        ...(PUBLIC_EID_WALLET_TOKEN
-            ? { Authorization: `Bearer ${PUBLIC_EID_WALLET_TOKEN}` }
-            : {}),
+    // vaultGqlRequest rather than a hand-rolled fetch: it throws on both a
+    // non-2xx and a GraphQL-level error (which arrives as HTTP 200 +
+    // {errors, data:null}). The previous inline version checked neither and
+    // fell back to `[]`, which is indistinguishable from "no documents" —
+    // `legalId` was then nulled out and the card silently reverted to its ADD
+    // state. Throwing hands control to the catch below, which leaves the last
+    // good values in place.
+    type TypedDocsResult = {
+        bindingDocuments: {
+            edges: { node: { id: string; parsed: ParsedBindingDoc | null } }[];
+        };
     };
-    const typedQuery = (type: string) =>
-        JSON.stringify({
-            query: `query($type: BindingDocumentType!) {
-                bindingDocuments(type: $type, first: 50) {
-                    edges { node { id parsed } }
-                }
-            }`,
-            variables: { type },
-        });
 
     try {
-        const [idDocRes, selfRes] = await Promise.all([
-            fetch(gqlUrl, { method: "POST", headers, body: typedQuery("id_document") }),
-            fetch(gqlUrl, { method: "POST", headers, body: typedQuery("self") }),
+        const [idDocData, selfData] = await Promise.all([
+            vaultGqlRequest<TypedDocsResult>(
+                gqlUrl,
+                enameHeader,
+                TYPED_BINDING_DOCS_QUERY,
+                { type: "id_document" },
+            ),
+            vaultGqlRequest<TypedDocsResult>(
+                gqlUrl,
+                enameHeader,
+                TYPED_BINDING_DOCS_QUERY,
+                { type: "self" },
+            ),
         ]);
 
-        const parseEdges = async (res: Response) => {
-            const json = await res.json();
-            return (json?.data?.bindingDocuments?.edges ?? []) as {
-                node: { id: string; parsed: ParsedBindingDoc | null };
-            }[];
-        };
-
-        const [idDocEdges, selfEdges] = await Promise.all([
-            parseEdges(idDocRes),
-            parseEdges(selfRes),
-        ]);
+        const idDocEdges = idDocData.bindingDocuments?.edges ?? [];
+        const selfEdges = selfData.bindingDocuments?.edges ?? [];
 
         const idDocEntry = idDocEdges.find((e) => e.node.parsed?.type === "id_document");
         legalId = idDocEntry?.node.parsed ? toLegalIdDoc(idDocEntry.node.parsed) : null;

--- a/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/main/+page.svelte
@@ -11,6 +11,7 @@ let hasMountedBefore = false;
 // instead of flashing the white loading splash. The component still kicks
 // off a fresh fetch on mount; the loaders write back into both the
 // component state and these slots so the next visit is also instant.
+import { registerPageCacheReset } from "../cache";
 import type { LegalIdDoc } from "./components/LegalIdAccordion.svelte";
 import type { SocialBindingDisplay } from "./components/SocialBindingAccordion.svelte";
 
@@ -23,6 +24,24 @@ let cachedSelfDocId: string | undefined;
 let cachedSocialBindingCount = 0;
 let cachedSocialBindingPreview: SocialBindingDisplay[] = [];
 let hasEverLoaded = false;
+
+// All of the above is one user's identity, and none of it survives a logout:
+// that's a client-side nav, which never re-evaluates this module, so the next
+// user to onboard on this device would be shown the previous user's name,
+// legal ID and contacts until the first fetch lands. `hasMountedBefore` goes
+// with them — a fresh session should play the entrance animation again.
+registerPageCacheReset(() => {
+    cachedUserData = undefined;
+    cachedEname = undefined;
+    cachedIsFake = undefined;
+    cachedLegalId = null;
+    cachedDisplayName = undefined;
+    cachedSelfDocId = undefined;
+    cachedSocialBindingCount = 0;
+    cachedSocialBindingPreview = [];
+    hasEverLoaded = false;
+    hasMountedBefore = false;
+});
 </script>
 
 <script lang="ts">

--- a/infrastructure/eid-wallet/src/routes/(app)/settings/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/settings/+page.svelte
@@ -15,6 +15,7 @@ import { isPermissionGranted } from "@choochmeque/tauri-plugin-notifications-api
 import { FaceIdIcon, Notification02Icon } from "@hugeicons/core-free-icons";
 import { checkStatus } from "@tauri-apps/plugin-biometric";
 import { getContext, onMount } from "svelte";
+import { clearAllPageCaches } from "../cache";
 
 const getGlobalState = getContext<() => GlobalState>("globalState");
 const setGlobalState =
@@ -84,6 +85,7 @@ async function performLogout() {
     isLogoutDrawerOpen = false;
     clearAllNotifications();
     await clearAllCachedPhotos();
+    clearAllPageCaches();
     if (!globalState) {
         console.error("Cannot logout: global state not ready");
         return;

--- a/infrastructure/eid-wallet/src/routes/(app)/social-bindings/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/social-bindings/+page.svelte
@@ -1,3 +1,11 @@
+<script module lang="ts">
+// Survives navigation, like the home screen's caches: returning to this page
+// paints the last known list immediately instead of showing a full-screen
+// spinner while every contact is re-resolved from scratch.
+let cachedContacts: SocialBindingDisplay[] = [];
+let hasEverLoaded = false;
+</script>
+
 <script lang="ts">
 import { AppNav } from "$lib/fragments";
 import type { GlobalState } from "$lib/global";
@@ -16,8 +24,8 @@ import SocialBindingDetailsSheet from "../main/components/SocialBindingDetailsSh
 const getGlobalState = getContext<() => GlobalState | undefined>("globalState");
 
 let globalState: GlobalState | undefined = $state(undefined);
-let contacts = $state<SocialBindingDisplay[]>([]);
-let loaded = $state(false);
+let contacts = $state<SocialBindingDisplay[]>(cachedContacts);
+let loaded = $state(hasEverLoaded);
 
 let detailsContact = $state<SocialBindingDisplay | null>(null);
 let detailsOpen = $state(false);
@@ -84,10 +92,16 @@ async function init() {
                     let name = counterpartyEname;
                     try {
                         const uri = await resolveVaultUri(counterpartyEname);
+                        // nameOnly: fetch just the two doc types that carry a
+                        // display name. Without it this drags every doc out of
+                        // the counterparty's vault — photo blobs included — to
+                        // render a single line of text.
                         name = await fetchNameFromVault(
                             uri,
                             counterpartyEname,
                             counterpartyEname,
+                            false,
+                            { nameOnly: true },
                         );
                     } catch {
                         // fallback to eName
@@ -103,6 +117,8 @@ async function init() {
             ),
         );
         contacts = rows;
+        cachedContacts = rows;
+        hasEverLoaded = true;
     } catch (err) {
         console.warn("[social-bindings] failed to load:", err);
     } finally {

--- a/infrastructure/eid-wallet/src/routes/(app)/social-bindings/+page.svelte
+++ b/infrastructure/eid-wallet/src/routes/(app)/social-bindings/+page.svelte
@@ -1,9 +1,18 @@
 <script module lang="ts">
+import { registerPageCacheReset } from "../cache";
+
 // Survives navigation, like the home screen's caches: returning to this page
 // paints the last known list immediately instead of showing a full-screen
 // spinner while every contact is re-resolved from scratch.
 let cachedContacts: SocialBindingDisplay[] = [];
 let hasEverLoaded = false;
+
+// It survives logout too — that's a client-side nav — so drop it there, or the
+// next user onboarding on this device gets a first paint of these contacts.
+registerPageCacheReset(() => {
+    cachedContacts = [];
+    hasEverLoaded = false;
+});
 </script>
 
 <script lang="ts">

--- a/infrastructure/eid-wallet/src/test/env-static-public.ts
+++ b/infrastructure/eid-wallet/src/test/env-static-public.ts
@@ -1,6 +1,6 @@
 // Test stub for SvelteKit's `$env/static/public` (aliased in vitest.config.ts).
 // Real values are injected by SvelteKit at build time; tests only need the
 // symbols to exist so modules that import them can load.
-export const PUBLIC_EID_WALLET_TOKEN = "";
-export const PUBLIC_PROVISIONER_URL = "";
-export const PUBLIC_REGISTRY_URL = "";
+export const PUBLIC_EID_WALLET_TOKEN = "test-token";
+export const PUBLIC_PROVISIONER_URL = "http://provisioner.test";
+export const PUBLIC_REGISTRY_URL = "http://registry.test";


### PR DESCRIPTION
# Description of change

Two fixes to how the eID wallet loads binding documents. The Social Bindings full
list downloaded every counterparty's photo blobs just to render their name (~2 MB
for 8 contacts — the reported 3–4s spinner). Separately, a failed refresh silently
wiped the Legal ID and Personal cards back to their empty state.
Also clears the pages' render caches on logout — they survived it, so a
different eName onboarding on the same device was briefly shown the previous
user's name, legal ID and contacts.

No env, config or infra changes — nothing to do on staging or prod.

## Issue Number

Closes #1080
Closes #1086

## Type of change

- **Fix (a change which fixes an issue)** ✅
- **Chore (refactoring, build scripts or anything else that isn't user-facing)** ✅ — `pnpm test` was broken

## How the change has been tested

`pnpm test`: 14 passing (up from 4). `svelte-check`: 0 errors. Biome clean.
The 4 new #1086 regression tests were confirmed to fail against the pre-fix code.

**#1080 — measured, not estimated.** Bytes are network-independent, so they hold
for the reporter as well as locally (the bug is invisible on localhost, where a
round trip costs ~1 ms): **257,467 → 442 bytes per contact**, i.e. ~2 MB → 3.4 KB
for 8. Registry round trips for the list drop from 16 to 8.

**#1086 — reproduced live, then verified.** Forced a GraphQL error (HTTP 200 +
`{errors, data:null}`) on the `id_document` query in the running app, same
starting state, only the fix differing:

| | with fix | without fix |
|---|---|---|
| console | `Failed to load binding documents` | **nothing** |
| Legal ID / badge | holds / VERIFIED | **reverts to ADD / UNVERIFIED** |

The "without fix" screen matches the ticket's screenshot. The silence is the
point — it's why the ticket had no error to report.

## Change checklist

- [x] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [x] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code

---

## Design decisions

**`nameOnly` trades one extra request for 250 KB, deliberately.** It issues two
typed queries instead of one broad one, so the raw request count goes *up* — but
they run in `Promise.all` (no extra round trip) and the photo blobs stop crossing
the wire. Round trips and bytes are the honest metric here; "fewer requests"
would have rejected the best fix.

**`resolveVaultUri` is memoised inside the function**, so all 7 callers benefit.
5-minute TTL (a vault URI only changes on re-provisioning), concurrent callers
share one in-flight promise, failures are never cached.

**#1086 was fixed by deleting a duplicate, not guarding it.**
`loadBindingDocuments` hand-rolled a fetch that already existed as
`vaultGqlRequest` — and the copy was the buggy one. Reusing the helper makes the
bug impossible by construction, and the fix is a net negative diff.

**`Promise.all` over `allSettled` in the count-only path.** Substituting an empty
result for a failed query isn't graceful degradation when the caller feeds it into
a full-store replace — it erases marks the user still has. Also realigns the
function with its sibling, which already used `Promise.all`.

## Detailed breakdown

**#1080.** The full list called `fetchNameFromVault` without `{ nameOnly: true }`,
taking the branch that returns *every* doc type from the counterparty's vault to
read one `name` field. The home screen passes the flag precisely to avoid this;
the list never got it. Separately, three layers resolved the same counterparty
independently — server logs showed 16 `/resolve` for 8 contacts on one load. The
page now also caches at module level like the home screen, so revisits paint the
known list instead of a full-screen spinner; that's perceived latency only, it
removes no requests.

**#1086.** Two paths turned a failure into "the user has no data", then wrote it
over good state: `loadBindingDocuments` checked neither `res.ok` nor `json.errors`,
so `edges` fell back to `[]` and `legalId` was nulled (`verified` derives from
`isFake === false || legalId !== null`, so the badge followed); and
`_loadPersonalBindingsCountOnly` swallowed rejections into an empty result that
`replaceAllPersonal` wrote over the store wholesale. Network-level throws were
*already* handled correctly — only response-level failures leaked, which is why it
looked intermittent and logged nothing. Both are reachable from the 30s interval,
`visibilitychange` and pull-to-refresh, so one blip visibly resets the card.

**Out of scope (deliberate).** `SOCIAL_BINDING_DOCS_QUERY` hardcodes `first: 50`
with no `pageInfo`, so the list is silently truncated at 50 docs — real bug, worth
its own ticket. The per-binding reconcile still costs a resolve + paginated read
each; batching needs server support. No in-flight guard was added to
`loadBindingDocuments`: once failures throw instead of producing empty data, two
concurrent successful runs write the same values.

**Cache lifetime.** The home and Social Bindings pages hold their last-known
values at module scope for instant repaints. That state outlives logout:
`performLogout` leaves with `goto("/")`, a client-side nav, and SvelteKit never
re-evaluates a module on client-side nav — so the next user onboarding on the
device got the previous user's data on first paint, with no spinner, since
`hasEverLoaded` was cached too. Pages now register a reset from
`<script module>` and `performLogout` calls `clearAllPageCaches()`, next to the
notification and photo clears already there. Scoping the cache by eName was the
obvious alternative but can't work: the eName only arrives after an async vault
read, by which point the cache has already painted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for social-binding vault lookups, including request sharing and retry handling.
  * Social-binding contacts now remain visible while refreshed after returning to the page.
  * Added an option to load only name-related documents when retrieving contact details.

* **Bug Fixes**
  * Binding document requests now correctly surface network and GraphQL errors.
  * Personal-binding loads fail clearly when required requests fail, while genuinely missing data remains supported.

* **Tests**
  * Added coverage for caching, concurrent lookups, error handling, and missing binding data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->