### PR TITLE
Add AccessGrant and CalendarAvailability ontology schemas

### DIFF
--- a/services/ontology/schemas/accessGrant.json
+++ b/services/ontology/schemas/accessGrant.json
@@ -1,0 +1,267 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "15d24c04-a4f3-4e45-a00e-0123926fbc87",
+  "title": "AccessGrant",
+  "type": "object",
+  "properties": {
+    "isReference": {
+      "type": "boolean"
+    },
+    "grantId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "grantorEName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "granteeType": {
+      "type": "string",
+      "enum": [
+        "ename",
+        "public"
+      ]
+    },
+    "granteeEName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "resourceType": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "permissions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*:[A-Za-z][A-Za-z0-9]*$"
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "revoked"
+      ]
+    },
+    "validFrom": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "validUntil": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "revokedAt": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "delegationAllowed": {
+      "type": "boolean"
+    },
+    "canonicalEnvelopeId": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "isReference",
+    "grantId",
+    "grantorEName",
+    "granteeType",
+    "createdAt"
+  ],
+  "oneOf": [
+    {
+      "title": "CanonicalAccessGrant",
+      "properties": {
+        "isReference": {
+          "const": false
+        },
+        "delegationAllowed": {
+          "const": false
+        }
+      },
+      "required": [
+        "isReference",
+        "grantId",
+        "grantorEName",
+        "granteeType",
+        "granteeEName",
+        "resourceType",
+        "permissions",
+        "status",
+        "validFrom",
+        "validUntil",
+        "createdAt",
+        "updatedAt",
+        "revision",
+        "revokedAt",
+        "delegationAllowed"
+      ],
+      "not": {
+        "required": [
+          "canonicalEnvelopeId"
+        ]
+      }
+    },
+    {
+      "title": "AccessGrantReference",
+      "properties": {
+        "isReference": {
+          "const": true
+        },
+        "granteeType": {
+          "const": "ename"
+        }
+      },
+      "required": [
+        "isReference",
+        "grantId",
+        "grantorEName",
+        "granteeType",
+        "granteeEName",
+        "canonicalEnvelopeId",
+        "createdAt"
+      ],
+      "not": {
+        "anyOf": [
+          {
+            "required": [
+              "resourceType"
+            ]
+          },
+          {
+            "required": [
+              "permissions"
+            ]
+          },
+          {
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "required": [
+              "validFrom"
+            ]
+          },
+          {
+            "required": [
+              "validUntil"
+            ]
+          },
+          {
+            "required": [
+              "updatedAt"
+            ]
+          },
+          {
+            "required": [
+              "revision"
+            ]
+          },
+          {
+            "required": [
+              "revokedAt"
+            ]
+          },
+          {
+            "required": [
+              "delegationAllowed"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "granteeType": {
+            "const": "ename"
+          }
+        },
+        "required": [
+          "granteeType"
+        ]
+      },
+      "then": {
+        "properties": {
+          "granteeEName": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "granteeType": {
+            "const": "public"
+          }
+        },
+        "required": [
+          "granteeType"
+        ]
+      },
+      "then": {
+        "properties": {
+          "granteeEName": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "isReference": {
+            "const": false
+          },
+          "status": {
+            "const": "revoked"
+          }
+        },
+        "required": [
+          "isReference",
+          "status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "revokedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/services/ontology/schemas/accessGrant.json
+++ b/services/ontology/schemas/accessGrant.json
@@ -80,7 +80,9 @@
       "format": "date-time"
     },
     "delegationAllowed": {
-      "type": "boolean"
+      "type": "boolean",
+      "const": false,
+      "description": "Delegation is not supported in version 1; canonical grants must explicitly store false."
     },
     "canonicalEnvelopeId": {
       "type": "string",
@@ -99,9 +101,6 @@
       "title": "CanonicalAccessGrant",
       "properties": {
         "isReference": {
-          "const": false
-        },
-        "delegationAllowed": {
           "const": false
         }
       },
@@ -258,6 +257,13 @@
           "revokedAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "revokedAt": {
+            "type": "null"
           }
         }
       }

--- a/services/ontology/schemas/calendarAvailability.json
+++ b/services/ontology/schemas/calendarAvailability.json
@@ -15,12 +15,12 @@
     "startDate": {
       "type": "string",
       "format": "date-time",
-      "description": "Inclusive interval start. Must be earlier than endDate; consumers must enforce this cross-field invariant."
+      "description": "Inclusive interval start. Writers must ensure it is earlier than endDate; readers must reject and report violations for audit attribution."
     },
     "endDate": {
       "type": "string",
       "format": "date-time",
-      "description": "Exclusive interval end. Must be later than startDate; consumers must enforce this cross-field invariant."
+      "description": "Exclusive interval end. Writers must ensure it is later than startDate; readers must reject and report violations for audit attribution."
     },
     "timeZone": {
       "type": "string",

--- a/services/ontology/schemas/calendarAvailability.json
+++ b/services/ontology/schemas/calendarAvailability.json
@@ -14,11 +14,13 @@
     },
     "startDate": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "description": "Inclusive interval start. Must be earlier than endDate; consumers must enforce this cross-field invariant."
     },
     "endDate": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "description": "Exclusive interval end. Must be later than startDate; consumers must enforce this cross-field invariant."
     },
     "timeZone": {
       "type": "string",
@@ -165,6 +167,13 @@
           "cancelledAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "cancelledAt": {
+            "type": "null"
           }
         }
       }

--- a/services/ontology/schemas/calendarAvailability.json
+++ b/services/ontology/schemas/calendarAvailability.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "a92c3675-dbc8-44f6-b24e-520eeadb8864",
+  "title": "CalendarAvailability",
+  "type": "object",
+  "properties": {
+    "availabilityId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ownerEName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "startDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "endDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "timeZone": {
+      "type": "string",
+      "minLength": 1
+    },
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 200
+    },
+    "bookingPolicy": {
+      "type": "string",
+      "enum": [
+        "open",
+        "emailVerified",
+        "eNameRequired"
+      ]
+    },
+    "verificationHoldMinutes": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1,
+      "maximum": 1440
+    },
+    "maxBookingsPerEmailPerDay": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1
+    },
+    "maxBookingsPerRequesterPerDay": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "revision": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "cancelledAt": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "availabilityId",
+    "ownerEName",
+    "startDate",
+    "endDate",
+    "timeZone",
+    "label",
+    "bookingPolicy",
+    "verificationHoldMinutes",
+    "maxBookingsPerEmailPerDay",
+    "maxBookingsPerRequesterPerDay",
+    "status",
+    "createdAt",
+    "updatedAt",
+    "revision",
+    "cancelledAt"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "bookingPolicy": {
+            "const": "emailVerified"
+          }
+        },
+        "required": [
+          "bookingPolicy"
+        ]
+      },
+      "then": {
+        "properties": {
+          "verificationHoldMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1440
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "bookingPolicy": {
+            "enum": [
+              "open",
+              "eNameRequired"
+            ]
+          }
+        },
+        "required": [
+          "bookingPolicy"
+        ]
+      },
+      "then": {
+        "properties": {
+          "verificationHoldMinutes": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "cancelled"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "cancelledAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Adds two proposed W3DS JSON Schema draft-07 ontologies:

- `AccessGrant` for canonical owner-to-grantee authorization and non-authoritative discovery references.
- `CalendarAvailability` for explicit owner-defined booking windows.

The schemas use newly generated UUIDv4 identifiers:

- AccessGrant: `15d24c04-a4f3-4e45-a00e-0123926fbc87`
- CalendarAvailability: `a92c3675-dbc8-44f6-b24e-520eeadb8864`

This PR is ready for maintainer review. Calex will not write records using these schema IDs until W3DS maintainers approve the model and merge/register the schemas.

## Motivation

Calex needs interoperable records for calendar visibility, delegated event operations, explicit availability windows, and public booking policy without introducing a local authorization database or copying authoritative calendar data outside users' eVaults.

## Maintainer questions / blockers

1. Is the canonical/reference AccessGrant pattern appropriate for cross-eVault discovery?
2. May a certified post-platform create a non-authoritative reference in a grantee's eVault?
3. Should raw AccessGrant and CalendarAvailability records remain owner-only under the current combined read/write ACL semantics?
4. Are namespaced permissions such as `calendar:viewBusy` acceptable?
5. Where should delegated actor and authorizing grant provenance live: MetaEnvelope metadata, audit records, or CalendarEvent fields?
6. Does grant creation/revocation require an owner signature flow?
7. What shared provisional-hold and atomic compare-and-create mechanism should prevent double booking?
8. Are draft-07 conditional keywords (`if`/`then`, `const`) supported by the deployed Ontology validation path?

## Scope

Only two new files under `services/ontology/schemas/` are added. No existing schema, runtime service, workflow, or deployment configuration is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added formal, strict validation contracts for access grants, including canonical vs reference shapes.
  * Enforced conditional rules for recipients, delegation behavior, permission/resource patterns, lifecycle status, and revocation timestamps.
  * Added a calendar availability schema with booking policies, verification hold timing, per-day limits, cancellation handling, and consistent audit fields.
  * Schemas now reject unsupported fields and require values to match defined formats, types, and allowed ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Type of change

- [x] New ontology schemas
- [ ] Runtime behavior change
- [ ] Deployment change

## Testing

- Both files parse as valid JSON.
- Repository CI: Check Format, Check Code, and Build All Packages.
- Review follow-up commits add lifecycle-state consistency constraints.
- The cross-field invariant `startDate < endDate` is documented but still requires maintainer guidance because JSON Schema draft-07 cannot enforce property ordering.

## Checklist

- [x] Changes are limited to ontology schema files.
- [x] No existing ontology IDs were modified.
- [x] No runtime, infrastructure, credential, or user-data changes are included.
- [x] Automated review comments were addressed or answered.
- [ ] Maintainer semantic review completed.
- [ ] Live Ontology publication process confirmed.

Related issue: none; this PR originates from the Calex integration proposal.