### PR TITLE
W3DS Health: observation-model health ontologies (34 schemas)

### DIFF
--- a/services/ontology/schemas/activeEnergySeries.json
+++ b/services/ontology/schemas/activeEnergySeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "915892f9-693b-4f4f-95e6-17f9ceeb55ff",
+  "title": "ActiveEnergySeries",
+  "description": "Raw active energy burned samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: kcal.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "kcal"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/activeEnergySeries.json
+++ b/services/ontology/schemas/activeEnergySeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/basalEnergySeries.json
+++ b/services/ontology/schemas/basalEnergySeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/basalEnergySeries.json
+++ b/services/ontology/schemas/basalEnergySeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "28b50f16-0db1-445b-9f45-0412e9ac3f56",
+  "title": "BasalEnergySeries",
+  "description": "Raw basal (resting) energy burned samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: kcal.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "kcal"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/biologicalSexFact.json
+++ b/services/ontology/schemas/biologicalSexFact.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/biologicalSexFact.json
+++ b/services/ontology/schemas/biologicalSexFact.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "ae1f8c24-41e6-4ec3-a128-07e423811332",
+  "title": "BiologicalSexFact",
+  "description": "A BiometricFact: one self-sufficient biometric attribute of a person — biological sex, e.g. \"male\". One envelope per (person × source). Identity fields (name, birthDate) are NOT here — they live in the shared User ontology.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": [
+        "string",
+        "boolean"
+      ]
+    },
+    "recordedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value"
+  ]
+}

--- a/services/ontology/schemas/bloodGlucoseObservation.json
+++ b/services/ontology/schemas/bloodGlucoseObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/bloodGlucoseObservation.json
+++ b/services/ontology/schemas/bloodGlucoseObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "79568be5-45b3-40ed-a96a-e5e39bc8814b",
+  "title": "BloodGlucoseObservation",
+  "description": "One spot measurement of blood glucose = one envelope. Canonical unit: mmol/L.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "mmol/L"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/bloodPressureObservation.json
+++ b/services/ontology/schemas/bloodPressureObservation.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "89b92b95-d631-4331-87c2-1fb4d2d695f4",
+  "title": "BloodPressureObservation",
+  "description": "One blood-pressure measurement event. Systolic and diastolic belong to the same measurement and are never split.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "systolic": {
+      "type": "number"
+    },
+    "diastolic": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "mmHg"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "systolic",
+    "diastolic",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/bloodPressureObservation.json
+++ b/services/ontology/schemas/bloodPressureObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/bloodTypeFact.json
+++ b/services/ontology/schemas/bloodTypeFact.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/bloodTypeFact.json
+++ b/services/ontology/schemas/bloodTypeFact.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0efd35ac-56f8-4e17-9109-63985f4547c3",
+  "title": "BloodTypeFact",
+  "description": "A BiometricFact: one self-sufficient biometric attribute of a person — blood type, e.g. \"A+\". One envelope per (person × source). Identity fields (name, birthDate) are NOT here — they live in the shared User ontology.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": [
+        "string",
+        "boolean"
+      ]
+    },
+    "recordedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value"
+  ]
+}

--- a/services/ontology/schemas/bodyFatPercentageObservation.json
+++ b/services/ontology/schemas/bodyFatPercentageObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "f41d7580-ff0c-497a-9f2e-04c8f060978e",
+  "title": "BodyFatPercentageObservation",
+  "description": "One spot measurement of body fat percentage = one envelope. Canonical unit: %.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "%"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/bodyFatPercentageObservation.json
+++ b/services/ontology/schemas/bodyFatPercentageObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/bodyMassObservation.json
+++ b/services/ontology/schemas/bodyMassObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "bb45aa75-6be7-4024-84f9-7c68426e04d9",
+  "title": "BodyMassObservation",
+  "description": "One spot measurement of body mass = one envelope. Canonical unit: kg.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "kg"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/bodyMassObservation.json
+++ b/services/ontology/schemas/bodyMassObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/bodyTemperatureObservation.json
+++ b/services/ontology/schemas/bodyTemperatureObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "85efca03-b202-4dc1-83b1-02c683d32b79",
+  "title": "BodyTemperatureObservation",
+  "description": "One spot measurement of body temperature = one envelope. Canonical unit: degC.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "degC"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/bodyTemperatureObservation.json
+++ b/services/ontology/schemas/bodyTemperatureObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/carbohydrateIntakeSeries.json
+++ b/services/ontology/schemas/carbohydrateIntakeSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "ed7f2e84-b6cf-4354-8a52-6ab128e28d7e",
+  "title": "CarbohydrateIntakeSeries",
+  "description": "Raw dietary carbohydrate intake (food-log entries) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: g.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "g"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/carbohydrateIntakeSeries.json
+++ b/services/ontology/schemas/carbohydrateIntakeSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/cyclingDistanceSeries.json
+++ b/services/ontology/schemas/cyclingDistanceSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/cyclingDistanceSeries.json
+++ b/services/ontology/schemas/cyclingDistanceSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "cf7d02f4-1a9c-40cf-be30-aaf5985a1738",
+  "title": "CyclingDistanceSeries",
+  "description": "Raw cycling distance samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: km.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "km"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/dailyActivitySummary.json
+++ b/services/ontology/schemas/dailyActivitySummary.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "571803c6-6324-4b69-9f8a-6dd2ec8c4d32",
+  "title": "DailyActivitySummary",
+  "description": "Source-computed daily activity totals and goals (goals are user-set facts, not derivable from series). One envelope per (person × day × source).",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "energyKcal": {
+      "type": "number"
+    },
+    "energyKcalGoal": {
+      "type": "number"
+    },
+    "exerciseMin": {
+      "type": "number"
+    },
+    "exerciseMinGoal": {
+      "type": "number"
+    },
+    "standHours": {
+      "type": "number"
+    },
+    "standHoursGoal": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date"
+  ]
+}

--- a/services/ontology/schemas/dailyActivitySummary.json
+++ b/services/ontology/schemas/dailyActivitySummary.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/device.json
+++ b/services/ontology/schemas/device.json
@@ -48,6 +48,10 @@
     "registeredAt": {
       "type": "string"
     },
+    "registeredBy": {
+      "type": "string",
+      "description": "w3id of the platform that provisioned this device vault"
+    },
     "dedupKey": {
       "type": "string"
     },

--- a/services/ontology/schemas/device.json
+++ b/services/ontology/schemas/device.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "d8b587d2-fbde-4b7d-87c8-a9b6c4199601",
+  "title": "Device",
+  "description": "A measuring device's passport, living on the DEVICE'S OWN eVault (the device has its own w3id). Health data always lives on the person's vault and references the device by w3id. Ownership can change (device sold) without touching the person's data.",
+  "type": "object",
+  "properties": {
+    "w3id": {
+      "type": "string",
+      "description": "the device's own @-prefixed w3id (self-reference)"
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "watch",
+        "phone",
+        "scale",
+        "app",
+        "other"
+      ]
+    },
+    "name": {
+      "type": "string"
+    },
+    "manufacturer": {
+      "type": "string"
+    },
+    "model": {
+      "type": "string"
+    },
+    "hardwareVersion": {
+      "type": "string"
+    },
+    "softwareVersion": {
+      "type": "string"
+    },
+    "serialNumber": {
+      "type": "string"
+    },
+    "ownerEName": {
+      "type": "string",
+      "description": "current owner (@-prefixed eName)"
+    },
+    "signature": {
+      "type": "string",
+      "description": "normalized source signature this passport was created from"
+    },
+    "registeredAt": {
+      "type": "string"
+    },
+    "dedupKey": {
+      "type": "string"
+    },
+    "contentHash": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "w3id",
+    "kind",
+    "ownerEName",
+    "signature",
+    "dedupKey",
+    "contentHash"
+  ]
+}

--- a/services/ontology/schemas/deviceLink.json
+++ b/services/ontology/schemas/deviceLink.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "76a5dae4-0543-4605-97fc-7478a8048d86",
+  "title": "DeviceLink",
+  "description": "Pure reference on the PERSON's vault: maps a device signature hash to the device's w3id. No device description is copied here (rule: canonical + reference, never a copy) — the passport lives on the device's own vault. Lets a fresh install rebuild signature→device mapping without re-provisioning duplicate vaults.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string"
+    },
+    "deviceEName": {
+      "type": "string"
+    },
+    "signatureHash": {
+      "type": "string",
+      "description": "sha256 of the normalized signature — the dedup key"
+    },
+    "linkedAt": {
+      "type": "string"
+    },
+    "dedupKey": {
+      "type": "string"
+    },
+    "contentHash": {
+      "type": "string"
+    },
+    "updatedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "deviceEName",
+    "signatureHash",
+    "dedupKey",
+    "contentHash"
+  ]
+}

--- a/services/ontology/schemas/deviceLink.json
+++ b/services/ontology/schemas/deviceLink.json
@@ -18,6 +18,10 @@
     "linkedAt": {
       "type": "string"
     },
+    "registeredBy": {
+      "type": "string",
+      "description": "w3id of the platform that created this link"
+    },
     "dedupKey": {
       "type": "string"
     },

--- a/services/ontology/schemas/energyIntakeSeries.json
+++ b/services/ontology/schemas/energyIntakeSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/energyIntakeSeries.json
+++ b/services/ontology/schemas/energyIntakeSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "120814e0-4c23-44c6-bb98-ca05d69c10f8",
+  "title": "EnergyIntakeSeries",
+  "description": "Raw dietary energy intake (food-log entries) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: kcal.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "kcal"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/environmentalAudioSeries.json
+++ b/services/ontology/schemas/environmentalAudioSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "8fcac357-0d1e-45fe-9d09-b89acb60520d",
+  "title": "EnvironmentalAudioSeries",
+  "description": "Raw environmental audio exposure samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: dBASPL.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "dBASPL"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/environmentalAudioSeries.json
+++ b/services/ontology/schemas/environmentalAudioSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/exerciseMinutesSeries.json
+++ b/services/ontology/schemas/exerciseMinutesSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/exerciseMinutesSeries.json
+++ b/services/ontology/schemas/exerciseMinutesSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "6a728f1b-0ed1-4fda-8cb6-c242b813d8a4",
+  "title": "ExerciseMinutesSeries",
+  "description": "Raw exercise minutes samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "min"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/fatIntakeSeries.json
+++ b/services/ontology/schemas/fatIntakeSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/fatIntakeSeries.json
+++ b/services/ontology/schemas/fatIntakeSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "10bed212-eb97-4062-b325-8c037eb07ace",
+  "title": "FatIntakeSeries",
+  "description": "Raw dietary fat intake (food-log entries) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: g.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "g"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/flightsClimbedSeries.json
+++ b/services/ontology/schemas/flightsClimbedSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/flightsClimbedSeries.json
+++ b/services/ontology/schemas/flightsClimbedSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "f9c6bf77-968c-41cd-abb8-232792223183",
+  "title": "FlightsClimbedSeries",
+  "description": "Raw flights of stairs climbed samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: count.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/headphoneAudioSeries.json
+++ b/services/ontology/schemas/headphoneAudioSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/headphoneAudioSeries.json
+++ b/services/ontology/schemas/headphoneAudioSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "f173f942-edbb-41ef-b964-65f3f2ddb084",
+  "title": "HeadphoneAudioSeries",
+  "description": "Raw headphone audio exposure samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: dBASPL.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "dBASPL"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/healthPhoto.json
+++ b/services/ontology/schemas/healthPhoto.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/healthPhoto.json
+++ b/services/ontology/schemas/healthPhoto.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "30b4bb28-494b-4d78-b99b-18f58a008da0",
+  "title": "HealthPhoto",
+  "description": "One private health image = one envelope, ACL [@owner]. The bytes are INLINE (data URI) by design: the platform blob store serves uploaded files from a public CDN regardless of the envelope ACL, so health imagery must not be stored there. Other envelopes (e.g. Meal) reference this envelope and never carry a second copy of the bytes.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "mediaType": {
+      "type": "string",
+      "enum": [
+        "image/jpeg",
+        "image/png",
+        "image/webp"
+      ]
+    },
+    "dataUri": {
+      "type": "string",
+      "description": "The image itself: data:<mediaType>;base64,…"
+    },
+    "byteSize": {
+      "type": "integer"
+    },
+    "width": {
+      "type": "integer"
+    },
+    "height": {
+      "type": "integer"
+    },
+    "md5": {
+      "type": "string",
+      "description": "md5 of the bytes — dedup key for re-uploads of the same photo"
+    },
+    "capturedAt": {
+      "type": "string"
+    },
+    "purpose": {
+      "type": "string",
+      "description": "What the photo is of, in neutral terms (\"meal\", \"document\", \"other\")"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "mediaType",
+    "dataUri",
+    "byteSize",
+    "md5",
+    "capturedAt"
+  ]
+}

--- a/services/ontology/schemas/heartRateSeries.json
+++ b/services/ontology/schemas/heartRateSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "a1bc3128-2248-4248-8411-1bdc5f81c151",
+  "title": "HeartRateSeries",
+  "description": "Raw heart rate samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: count/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count/min"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/heartRateSeries.json
+++ b/services/ontology/schemas/heartRateSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/heartRateVariabilitySeries.json
+++ b/services/ontology/schemas/heartRateVariabilitySeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/heartRateVariabilitySeries.json
+++ b/services/ontology/schemas/heartRateVariabilitySeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "d613e09f-2f41-43d8-b92d-5b84cbf0aa30",
+  "title": "HeartRateVariabilitySeries",
+  "description": "Raw heart rate variability (SDNN) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: ms.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "ms"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/heightObservation.json
+++ b/services/ontology/schemas/heightObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/heightObservation.json
+++ b/services/ontology/schemas/heightObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "c5cf620f-2b75-489d-8937-5f77e8e2e23e",
+  "title": "HeightObservation",
+  "description": "One spot measurement of height = one envelope. Canonical unit: cm.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "cm"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/leanBodyMassObservation.json
+++ b/services/ontology/schemas/leanBodyMassObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/leanBodyMassObservation.json
+++ b/services/ontology/schemas/leanBodyMassObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "f262892c-98e9-4b66-a6af-eea4c9ef94bc",
+  "title": "LeanBodyMassObservation",
+  "description": "One spot measurement of lean body mass = one envelope. Canonical unit: kg.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "kg"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/meal.json
+++ b/services/ontology/schemas/meal.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "schemaId": "879df524-f062-44eb-9a05-52dc62884e6c",
   "title": "Meal",
-  "description": "One meal. The photo is embedded INSIDE this private envelope (downscaled data URI) — never in public blob storage. nutritionEstimate is STRUCTURALLY an estimate (AI vision output) — readers must present it as an estimate, never as a measured fact.",
+  "description": "One meal. The photo is NOT embedded here: `photo.ref` points at the HealthPhoto envelope that holds the bytes (canonical + reference, never a copy). nutritionEstimate is STRUCTURALLY an estimate (AI vision output, `derivedFrom` names the photo it was read from) — readers must present it as an estimate, never as a measured fact.",
   "type": "object",
   "properties": {
     "subject": {
@@ -64,16 +64,30 @@
         "snack"
       ]
     },
+    "mealTypeSource": {
+      "type": "string",
+      "enum": [
+        "user",
+        "inferred"
+      ],
+      "description": "user = stated by the person; inferred = guessed from local time of day + dish. An inferred type must not be presented as stated."
+    },
     "comment": {
-      "type": "string"
+      "type": "string",
+      "description": "The person's own words, stored verbatim"
     },
     "place": {
       "type": "string"
     },
     "photo": {
       "type": "object",
+      "description": "REFERENCE to the HealthPhoto envelope holding the bytes — never a copy of the image.",
       "properties": {
-        "dataUri": {
+        "ref": {
+          "type": "string",
+          "description": "w3ds://envelope?id=@owner/<metaEnvelopeId>"
+        },
+        "mediaType": {
           "type": "string"
         },
         "width": {
@@ -84,7 +98,7 @@
         }
       },
       "required": [
-        "dataUri"
+        "ref"
       ]
     },
     "nutritionEstimate": {
@@ -136,6 +150,18 @@
         },
         "totalKcal": {
           "type": "number"
+        },
+        "model": {
+          "type": "string",
+          "description": "Estimator identity (model id) — provenance of the estimate itself"
+        },
+        "notes": {
+          "type": "string",
+          "description": "Estimator's stated assumptions/uncertainties"
+        },
+        "derivedFrom": {
+          "type": "string",
+          "description": "w3ds:// reference to the HealthPhoto this estimate was derived from"
         }
       },
       "required": [

--- a/services/ontology/schemas/meal.json
+++ b/services/ontology/schemas/meal.json
@@ -93,7 +93,11 @@
       "properties": {
         "method": {
           "type": "string",
-          "const": "ai-vision"
+          "enum": [
+            "ai-vision",
+            "food-log"
+          ],
+          "description": "ai-vision = AI photo analysis; food-log = user-entered food-app values"
         },
         "estimatedAt": {
           "type": "string"

--- a/services/ontology/schemas/meal.json
+++ b/services/ontology/schemas/meal.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "879df524-f062-44eb-9a05-52dc62884e6c",
+  "title": "Meal",
+  "description": "One meal. The photo is embedded INSIDE this private envelope (downscaled data URI) — never in public blob storage. nutritionEstimate is STRUCTURALLY an estimate (AI vision output) — readers must present it as an estimate, never as a measured fact.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "mealType": {
+      "type": "string",
+      "enum": [
+        "breakfast",
+        "lunch",
+        "dinner",
+        "snack"
+      ]
+    },
+    "comment": {
+      "type": "string"
+    },
+    "place": {
+      "type": "string"
+    },
+    "photo": {
+      "type": "object",
+      "properties": {
+        "dataUri": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "dataUri"
+      ]
+    },
+    "nutritionEstimate": {
+      "type": "object",
+      "description": "AI ESTIMATE — not a measurement",
+      "properties": {
+        "method": {
+          "type": "string",
+          "const": "ai-vision"
+        },
+        "estimatedAt": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "massG": {
+                "type": "number"
+              },
+              "kcal": {
+                "type": "number"
+              },
+              "proteinG": {
+                "type": "number"
+              },
+              "fatG": {
+                "type": "number"
+              },
+              "carbsG": {
+                "type": "number"
+              },
+              "confidence": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "totalKcal": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "method",
+        "estimatedAt",
+        "items"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "timestamp",
+    "date"
+  ]
+}

--- a/services/ontology/schemas/meal.json
+++ b/services/ontology/schemas/meal.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/oxygenSaturationSeries.json
+++ b/services/ontology/schemas/oxygenSaturationSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "a58b8b8a-0651-414d-9836-269dd6b2ed3d",
+  "title": "OxygenSaturationSeries",
+  "description": "Raw blood oxygen saturation samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: %.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "%"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/oxygenSaturationSeries.json
+++ b/services/ontology/schemas/oxygenSaturationSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/proteinIntakeSeries.json
+++ b/services/ontology/schemas/proteinIntakeSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "6b591d75-2dce-4b2c-a8a3-eb236b5a4a89",
+  "title": "ProteinIntakeSeries",
+  "description": "Raw dietary protein intake (food-log entries) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: g.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "g"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/proteinIntakeSeries.json
+++ b/services/ontology/schemas/proteinIntakeSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/respiratoryRateSeries.json
+++ b/services/ontology/schemas/respiratoryRateSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "a3a2b37a-1120-4b02-abba-41baff0e6c3e",
+  "title": "RespiratoryRateSeries",
+  "description": "Raw respiratory rate samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: count/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count/min"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/respiratoryRateSeries.json
+++ b/services/ontology/schemas/respiratoryRateSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/restingHeartRateObservation.json
+++ b/services/ontology/schemas/restingHeartRateObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "3ef62702-c021-4367-b152-b6e257f2ad30",
+  "title": "RestingHeartRateObservation",
+  "description": "One spot measurement of resting heart rate (device-computed daily value) = one envelope. Canonical unit: count/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count/min"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/restingHeartRateObservation.json
+++ b/services/ontology/schemas/restingHeartRateObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/skinTypeFact.json
+++ b/services/ontology/schemas/skinTypeFact.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/skinTypeFact.json
+++ b/services/ontology/schemas/skinTypeFact.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "8d4fe698-9d6b-4a54-a973-d3964e7bcd4a",
+  "title": "SkinTypeFact",
+  "description": "A BiometricFact: one self-sufficient biometric attribute of a person — skin type on the Fitzpatrick scale, e.g. \"Fitzpatrick II\". One envelope per (person × source). Identity fields (name, birthDate) are NOT here — they live in the shared User ontology.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": [
+        "string",
+        "boolean"
+      ]
+    },
+    "recordedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value"
+  ]
+}

--- a/services/ontology/schemas/sleepSession.json
+++ b/services/ontology/schemas/sleepSession.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/sleepSession.json
+++ b/services/ontology/schemas/sleepSession.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "f53146ba-0f25-4d1d-b612-35fb464d9a2e",
+  "title": "SleepSession",
+  "description": "One sleep session (a night). Neutral stage vocabulary: inBed | awake | light | deep | rem | asleep (unspecified). date = local morning of wake-up.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "startDate": {
+      "type": "string"
+    },
+    "endDate": {
+      "type": "string"
+    },
+    "stages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "stage": {
+            "type": "string",
+            "enum": [
+              "inBed",
+              "awake",
+              "light",
+              "deep",
+              "rem",
+              "asleep"
+            ]
+          },
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "stage",
+          "start",
+          "end"
+        ]
+      }
+    },
+    "totals": {
+      "type": "object",
+      "properties": {
+        "inBedMin": {
+          "type": "number"
+        },
+        "asleepMin": {
+          "type": "number"
+        },
+        "lightMin": {
+          "type": "number"
+        },
+        "deepMin": {
+          "type": "number"
+        },
+        "remMin": {
+          "type": "number"
+        },
+        "awakeMin": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "startDate",
+    "endDate",
+    "stages",
+    "totals"
+  ]
+}

--- a/services/ontology/schemas/standMinutesSeries.json
+++ b/services/ontology/schemas/standMinutesSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/standMinutesSeries.json
+++ b/services/ontology/schemas/standMinutesSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "3bba969c-1b36-4b93-b4b4-b9fdf856c39a",
+  "title": "StandMinutesSeries",
+  "description": "Raw standing minutes samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "min"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/stepLengthSeries.json
+++ b/services/ontology/schemas/stepLengthSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/stepLengthSeries.json
+++ b/services/ontology/schemas/stepLengthSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "4e0cfb8a-99f2-4294-8432-41190bc8b3e7",
+  "title": "StepLengthSeries",
+  "description": "Raw walking step length samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: cm.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "cm"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/stepSeries.json
+++ b/services/ontology/schemas/stepSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "4690ca86-3a4a-448a-b505-b4de58902546",
+  "title": "StepSeries",
+  "description": "Raw step count samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: count.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/stepSeries.json
+++ b/services/ontology/schemas/stepSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/vO2MaxObservation.json
+++ b/services/ontology/schemas/vO2MaxObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "49efc0c5-2851-4e3c-8759-957d11427edf",
+  "title": "VO2MaxObservation",
+  "description": "One spot measurement of VO2Max = one envelope. Canonical unit: mL/kg/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "mL/kg/min"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/vo2MaxObservation.json
+++ b/services/ontology/schemas/vo2MaxObservation.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "49efc0c5-2851-4e3c-8759-957d11427edf",
+  "title": "VO2MaxObservation",
+  "description": "One spot measurement of VO2Max = one envelope. Canonical unit: mL/kg/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "mL/kg/min"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/walkingAsymmetrySeries.json
+++ b/services/ontology/schemas/walkingAsymmetrySeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/walkingAsymmetrySeries.json
+++ b/services/ontology/schemas/walkingAsymmetrySeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "5c3bac68-1902-4d18-8aa5-6f456dee2156",
+  "title": "WalkingAsymmetrySeries",
+  "description": "Raw walking asymmetry percentage samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: %.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "%"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/walkingDoubleSupportSeries.json
+++ b/services/ontology/schemas/walkingDoubleSupportSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/walkingDoubleSupportSeries.json
+++ b/services/ontology/schemas/walkingDoubleSupportSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "5a1ff54e-37f9-42bb-87c9-b97248848553",
+  "title": "WalkingDoubleSupportSeries",
+  "description": "Raw walking double-support percentage samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: %.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "%"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/walkingHeartRateObservation.json
+++ b/services/ontology/schemas/walkingHeartRateObservation.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/walkingHeartRateObservation.json
+++ b/services/ontology/schemas/walkingHeartRateObservation.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "957e35c5-cbda-4b9f-b92b-9db1a519c0bc",
+  "title": "WalkingHeartRateObservation",
+  "description": "One spot measurement of average walking heart rate (device-computed daily value) = one envelope. Canonical unit: count/min.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": "number"
+    },
+    "unit": {
+      "type": "string",
+      "const": "count/min"
+    },
+    "measuredAt": {
+      "type": "string",
+      "description": "ISO 8601 with offset"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value",
+    "unit",
+    "measuredAt"
+  ]
+}

--- a/services/ontology/schemas/walkingRunningDistanceSeries.json
+++ b/services/ontology/schemas/walkingRunningDistanceSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/walkingRunningDistanceSeries.json
+++ b/services/ontology/schemas/walkingRunningDistanceSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "e7d4f532-8999-47da-b96f-e46402a24f78",
+  "title": "WalkingRunningDistanceSeries",
+  "description": "Raw walking+running distance samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: km.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "km"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/walkingSpeedSeries.json
+++ b/services/ontology/schemas/walkingSpeedSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/walkingSpeedSeries.json
+++ b/services/ontology/schemas/walkingSpeedSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "a436853e-4fa1-4f55-9527-210579157ce3",
+  "title": "WalkingSpeedSeries",
+  "description": "Raw walking speed samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: km/h.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "km/h"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/waterIntakeSeries.json
+++ b/services/ontology/schemas/waterIntakeSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "9596b22f-db7c-4801-a8cb-9101ce3e58dc",
+  "title": "WaterIntakeSeries",
+  "description": "Raw water intake (food-log entries) samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [startEpochSeconds, endEpochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: mL.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "mL"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "interval"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}

--- a/services/ontology/schemas/waterIntakeSeries.json
+++ b/services/ontology/schemas/waterIntakeSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/wheelchairUseFact.json
+++ b/services/ontology/schemas/wheelchairUseFact.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "6ef27c3e-c684-48b2-937c-838caa473f66",
+  "title": "WheelchairUseFact",
+  "description": "A BiometricFact: one self-sufficient biometric attribute of a person — whether the person uses a wheelchair (boolean). One envelope per (person × source). Identity fields (name, birthDate) are NOT here — they live in the shared User ontology.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "value": {
+      "type": [
+        "string",
+        "boolean"
+      ]
+    },
+    "recordedAt": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "value"
+  ]
+}

--- a/services/ontology/schemas/wheelchairUseFact.json
+++ b/services/ontology/schemas/wheelchairUseFact.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/workout.json
+++ b/services/ontology/schemas/workout.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/workout.json
+++ b/services/ontology/schemas/workout.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "c693b036-9cd8-45d7-b53f-c5f068ab58b8",
+  "title": "Workout",
+  "description": "A workout/training session. The GPS route lives INSIDE this private envelope (encoded polyline5) — never in public blob storage. avgHeartRate/maxHeartRate/stats are DEVICE-COMPUTED aggregates over the workout window, not copies of series data. dedupKey = provenance-scoped external id.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "activityType": {
+      "type": "string",
+      "description": "Open neutral enum: Running, Walking, Cycling, Swimming, …"
+    },
+    "startDate": {
+      "type": "string"
+    },
+    "endDate": {
+      "type": "string"
+    },
+    "durationSec": {
+      "type": "number"
+    },
+    "distanceKm": {
+      "type": "number"
+    },
+    "activeEnergyKcal": {
+      "type": "number"
+    },
+    "avgHeartRate": {
+      "type": "number"
+    },
+    "maxHeartRate": {
+      "type": "number"
+    },
+    "elevationAscendedM": {
+      "type": "number"
+    },
+    "stats": {
+      "type": "object",
+      "description": "Device-computed per-metric aggregates, keyed by neutral metric keys",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "min": {
+            "type": "number"
+          },
+          "max": {
+            "type": "number"
+          },
+          "avg": {
+            "type": "number"
+          },
+          "sum": {
+            "type": "number"
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "description": "Canonical GPS route, INSIDE the private envelope",
+      "properties": {
+        "format": {
+          "type": "string",
+          "const": "polyline5"
+        },
+        "data": {
+          "type": "string"
+        },
+        "pointCount": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "format",
+        "data",
+        "pointCount"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "activityType",
+    "startDate",
+    "endDate",
+    "durationSec"
+  ]
+}

--- a/services/ontology/schemas/wristTemperatureSeries.json
+++ b/services/ontology/schemas/wristTemperatureSeries.json
@@ -23,6 +23,10 @@
         "source": {
           "type": "string"
         },
+        "platform": {
+          "type": "string",
+          "description": "w3id (@eName) of the platform that wrote this envelope — machine-readable authorship; resolve it to read that platform's self-description"
+        },
         "externalId": {
           "type": "string"
         },

--- a/services/ontology/schemas/wristTemperatureSeries.json
+++ b/services/ontology/schemas/wristTemperatureSeries.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "d621eca8-4dde-4677-a60f-c45bdf908d97",
+  "title": "WristTemperatureSeries",
+  "description": "Raw wrist temperature during sleep samples over one local day from ONE device. One envelope per (person × day × device) — multiple devices coexist as separate envelopes; merging is a reader-side presentation concern. Sample = [epochSeconds, value], epoch = UTC seconds, utcOffset gives the person's local offset. `stats` is DERIVED from samples (cheap-read preview) — samples are the source of truth. Canonical unit: degC.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "description": "@-prefixed eName of the person this data is about"
+    },
+    "device": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "w3id (@eName) of the measuring device's OWN eVault, where its Device passport lives; null if unknown"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Import provenance. Vendor identity lives HERE only (source), never in metric keys.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "externalId": {
+          "type": "string"
+        },
+        "sourceName": {
+          "type": "string"
+        },
+        "deviceSignature": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source"
+      ]
+    },
+    "dedupKey": {
+      "type": "string",
+      "description": "Writer's idempotency key, unique within this ontology on the vault"
+    },
+    "contentHash": {
+      "type": "string",
+      "description": "Writer-maintained md5 of the payload; recomputed on every rewrite"
+    },
+    "updatedAt": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "local day — chunk key"
+    },
+    "utcOffset": {
+      "type": "string",
+      "pattern": "^[+-]\\d{2}:\\d{2}$"
+    },
+    "unit": {
+      "type": "string",
+      "const": "degC"
+    },
+    "sampleType": {
+      "type": "string",
+      "const": "point"
+    },
+    "samples": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 3
+      }
+    },
+    "stats": {
+      "type": "object",
+      "description": "DERIVED from samples — preview only",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "avg": {
+          "type": "number"
+        },
+        "sum": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "required": [
+    "subject",
+    "provenance",
+    "dedupKey",
+    "contentHash",
+    "date",
+    "utcOffset",
+    "unit",
+    "sampleType",
+    "samples",
+    "stats"
+  ]
+}


### PR DESCRIPTION
Registers the ontology family of **W3DS Health** — a post-platform that puts a person's health data (wearable exports: raw metric series, workouts with GPS routes, sleep, meals) on their own eVault.

## Families

| Family | Schemas | Cardinality |
|---|---|---|
| BiometricFact | bloodTypeFact, biologicalSexFact, skinTypeFact, wheelchairUseFact | 1 / person × source |
| Observation | bodyMass, height, bloodPressure, bodyTemperature, bloodGlucose, vO2Max, restingHeartRate, bodyFatPercentage, leanBodyMass (×Observation) | 1 / measurement |
| Series | heartRate, heartRateVariability, step, walkingRunningDistance, cyclingDistance, activeEnergy, basalEnergy, exerciseMinutes, standMinutes, flightsClimbed, oxygenSaturation, respiratoryRate, wristTemperature, environmentalAudio, headphoneAudio (×Series) | 1 / person × day × device |
| Event | workout, sleepSession, meal, dailyActivitySummary | 1 / event |
| Infrastructure | device, deviceLink | 1 / device |

## Design principles

- **Triple-like granularity** — one ontology per parameter: a reader looking for heart rate queries HeartRateSeries only; a smart scale writes BodyMassObservation only.
- **No duplication of identity** — name/birthDate stay in the shared `user.json`; a health profile is a documented view, not an ontology.
- **Multi-source by design** — series envelopes are keyed per (person × day × device); a watch and a phone coexist without conflict.
- **Raw samples preserved** (epoch-second precision); every derived block (`stats`) is explicitly documented as derived.
- **Private by default** — ACL `[@owner]`; private bytes (meal photos, GPS polylines) live inside envelopes, never in public blob storage.
- **Devices are first-class** — each device gets its own w3id + eVault with a `device` passport; person's envelopes reference it by w3id, so a device can be sold/re-owned without touching the person's data. For this we currently use the demo provisioner verificationId — a production verificationId for w3ds-health would be appreciated.

Live self-description (kept in lock-step with code): PlatformProfile envelope `c46d5d86-c720-5278-9952-d006db9d0585` on platform vault `@1a73617b-7b1d-56a8-88a9-963bcf9dfcc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized JSON Schema contracts for many additional health and wellness ontology types, including new observation, fact, and time-series envelopes (e.g., energy/glucose measurements, blood pressure, VO2 max, sleep sessions).
  * Introduced a new optional `provenance.platform` field across multiple schemas to capture machine-readable authorship, and added `registeredBy` support on device-related schemas.

* **Enhancements**
  * Strengthened validation consistency for units/sample types, timestamps, and derived `stats` requirements across the updated contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->