### PR TITLE
Register 80hours reminder and platform schemas

### DIFF
--- a/services/ontology/schemas/groupReference.json
+++ b/services/ontology/schemas/groupReference.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f410",
+  "title": "GroupReference",
+  "type": "object",
+  "description": "A user-side reference to the canonical GroupManifest for a company or project. It intentionally carries no duplicate group membership or role data.",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "isReference",
+    "entityType",
+    "canonicalEntityId",
+    "canonicalOwnerEName",
+    "canonicalEnvelopeId",
+    "groupManifestEnvelopeId",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "isReference": { "type": "boolean", "const": true },
+    "entityType": { "type": "string", "enum": ["company", "project"] },
+    "canonicalEntityId": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "canonicalEnvelopeId": { "type": "string" },
+    "groupManifestEnvelopeId": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/services/ontology/schemas/platformSelfDescription.json
+++ b/services/ontology/schemas/platformSelfDescription.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f411",
+  "title": "PlatformSelfDescription",
+  "type": "object",
+  "description": "A machine-readable self-description of a W3DS post-platform, stored on the platform's own eVault.",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "type": "string" },
+    "platformName": { "type": "string" },
+    "displayName": { "type": "string" },
+    "format": { "type": "string" },
+    "content": { "type": "string" },
+    "contentSha256": { "type": "string" },
+    "sourceUrl": { "type": "string" },
+    "profileEnvelopeId": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": [
+    "id",
+    "platformName",
+    "displayName",
+    "format",
+    "content",
+    "contentSha256",
+    "profileEnvelopeId",
+    "createdAt",
+    "updatedAt"
+  ]
+}

--- a/services/ontology/schemas/reminder.json
+++ b/services/ontology/schemas/reminder.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "schemaId": "0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f412",
+  "title": "Reminder",
+  "type": "object",
+  "description": "A universal reminder/alarm envelope. It can point to any W3DS subject, not only a task. The timing model is compatible with iCalendar VALARM absolute triggers.",
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "canonicalOwnerEName",
+    "createdBy",
+    "recipientEName",
+    "triggerAt",
+    "action",
+    "summary",
+    "status",
+    "relatedSubject",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "id": { "type": "string" },
+    "canonicalOwnerEName": { "type": "string" },
+    "createdBy": { "type": "string" },
+    "recipientEName": { "type": "string" },
+    "triggerAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Absolute reminder trigger time, equivalent to VALARM TRIGGER;VALUE=DATE-TIME."
+    },
+    "timezone": { "type": "string", "default": "UTC" },
+    "action": {
+      "type": "string",
+      "enum": ["display", "email", "audio"],
+      "default": "display"
+    },
+    "summary": { "type": "string" },
+    "description": { "type": "string" },
+    "status": {
+      "type": "string",
+      "enum": ["scheduled", "acknowledged", "dismissed", "cancelled"],
+      "default": "scheduled"
+    },
+    "acknowledgedAt": { "type": ["string", "null"], "format": "date-time" },
+    "snoozedUntil": { "type": ["string", "null"], "format": "date-time" },
+    "standard": {
+      "type": "string",
+      "description": "Optional interoperability hint, for example RFC5545-VALARM."
+    },
+    "triggerKind": {
+      "type": "string",
+      "enum": ["absolute", "relative"],
+      "default": "absolute"
+    },
+    "relatedSubject": {
+      "type": "object",
+      "description": "Structured pointer to the subject. Readers can resolve this to learn whether the subject is a task, event, message, birthday, payment, shopping item, or another W3DS entity.",
+      "required": ["id"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string" },
+        "ontologyId": { "type": "string" },
+        "canonicalOwnerEName": { "type": "string" },
+        "canonicalEnvelopeId": { "type": ["string", "null"] },
+        "type": { "type": "string" }
+      }
+    },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/services/ontology/schemas/task.json
+++ b/services/ontology/schemas/task.json
@@ -63,23 +63,26 @@
     "deadline": { "type": ["string", "null"], "format": "date-time" },
     "blockedByTaskIds": { "type": "array", "items": { "type": "string" } },
     "blocksTaskIds": { "type": "array", "items": { "type": "string" } },
-    "notes": { "type": "array", "items": { "$ref": "#/definitions/note" } },
-    "attachments": { "type": "array", "items": { "$ref": "#/definitions/attachment" } },
-    "subtasks": { "type": "array", "items": { "$ref": "#/definitions/subtask" } },
-    "effectiveAcl": { "type": "array", "items": { "type": "string" } },
+    "notes": { "type": "array", "items": { "$ref": "#/definitions/note" }, "description": "Deprecated legacy inline copy. New notes are canonical TaskNote envelopes." },
+    "attachments": { "type": "array", "items": { "$ref": "#/definitions/attachment" }, "description": "Deprecated legacy inline copy. New attachments are canonical TaskAttachment envelopes." },
+    "subtasks": { "type": "array", "items": { "$ref": "#/definitions/subtask" }, "description": "Deprecated legacy inline copy. New subtasks are Task envelopes linked through task relations." },
+    "effectiveAcl": { "type": "array", "items": { "type": "string" }, "description": "Deprecated projection. The sole authoritative access list is MetaEnvelope.acl." },
     "manualAclAdds": { "type": "array", "items": { "type": "string" } },
     "aiDraftSource": { "type": "string" },
     "eVaultSyncStatus": { "type": "string", "enum": ["synced", "pending", "failed"] },
     "eVaultSyncError": { "type": ["string", "null"] },
     "createdAt": { "type": "string", "format": "date-time" },
     "updatedAt": { "type": "string", "format": "date-time" },
-    "closedAt": { "type": ["string", "null"], "format": "date-time" }
+    "closedAt": { "type": ["string", "null"], "format": "date-time" },
+    "isDeleted": {
+      "type": "boolean",
+      "default": false,
+      "description": "Soft-delete marker. Readers should hide deleted tasks from ordinary lists while preserving the canonical envelope for references and audit."
+    }
   },
   "required": [
     "id",
     "canonicalOwnerEName",
-    "relatedProjectIds",
-    "relatedCompanyIds",
     "title",
     "description",
     "createdBy",
@@ -87,18 +90,11 @@
     "status",
     "priority",
     "progressPercent",
-    "estimatedHours",
-    "deadline",
     "blockedByTaskIds",
     "blocksTaskIds",
-    "notes",
-    "attachments",
-    "subtasks",
-    "effectiveAcl",
     "manualAclAdds",
     "createdAt",
-    "updatedAt",
-    "closedAt"
+    "updatedAt"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- add universal Reminder ontology: 0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f412
- add PlatformSelfDescription ontology: 0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f411
- add GroupReference ontology: 0f9a3cb8-4a9f-4b5f-a1fa-3a4c2eb1f410
- align Task with source-agnostic draft tasks and MetaEnvelope ACL as the sole access authority
- retain legacy inline task copies as optional, explicitly deprecated compatibility fields

## Validation
- parsed all changed JSON schemas with jq
- verified the schema service discovers schemas by schemaId from this directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation standards for group references, platform descriptions, and reminders.
  * Reminders now support flexible timing, delivery methods, statuses, acknowledgments, snoozing, and subject references.

* **Improvements**
  * Updated task records to support soft deletion.
  * Relaxed requirements for legacy task details and relationships, improving compatibility with partial task data.
  * Marked legacy task fields as deprecated while retaining support for existing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->