### PR TITLE
Fix awareness webhook delivery reliability

### DIFF
--- a/docs/docs/Services/Awareness-as-a-Service.md
+++ b/docs/docs/Services/Awareness-as-a-Service.md
@@ -141,11 +141,11 @@ AaaS is designed to be dropped in with **zero receiver-side changes**:
 1. **Backfill.** AaaS runs on the same node as evault-core's Neo4j. The
    `backfill` script reads existing MetaEnvelopes straight from the graph and
    seeds the `packets` table (history only — it does not queue deliveries).
-2. **Catch-all seeding.** On every launch, AaaS ensures each platform currently
-   in the registry has an approved consumer and a catch-all subscription
-   pointing at `<platform>/api/webhook`. Existing platforms therefore keep
-   receiving every packet exactly as before, and can later narrow their
-   subscriptions to specific ontologies or eVaults.
+2. **Catch-all reconciliation.** On every launch and once per configured sync
+   interval, AaaS ensures each platform currently in the registry has an
+   approved consumer and an active catch-all subscription pointing at
+   `<platform>/api/webhook`. Existing and newly registered platforms therefore
+   keep receiving every packet exactly as before.
 3. **evault-core switch.** evault-core's `deliverWebhooks`/`getActivePlatforms`
    are removed; a single `notifyAwareness` POST forwards each packet to AaaS.
 
@@ -162,6 +162,7 @@ AaaS is designed to be dropped in with **zero receiver-side changes**:
 | `AAAS_JWT_SECRET` | Signs portal session JWTs |
 | `AWARENESS_MAX_ATTEMPTS` | Delivery attempts before dead-lettering (default 3) |
 | `AWARENESS_DELIVERY_POLL_MS` | Delivery engine poll interval (default 2000) |
+| `AWARENESS_REGISTRY_SYNC_MS` | Registry catch-all reconciliation interval (default 60000; 0 disables periodic sync) |
 | `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` | Standard eVault Neo4j vars — reused by the one-time backfill |
 | `PUBLIC_AWARENESS_API_URL` | (portal) AaaS API base URL |
 
@@ -172,6 +173,6 @@ AaaS is designed to be dropped in with **zero receiver-side changes**:
 pnpm --filter awareness-service-api build
 pnpm --filter awareness-service-api migration:run
 pnpm --filter awareness-service-api backfill        # one-time, from Neo4j
-pnpm --filter awareness-service-api dev             # API (seeds catch-all on launch)
+pnpm --filter awareness-service-api dev             # API (keeps registry catch-alls synced)
 pnpm --filter awareness-portal dev                  # portal
 ```

--- a/infrastructure/evault-core/src/core/protocol/graphql-server.ts
+++ b/infrastructure/evault-core/src/core/protocol/graphql-server.ts
@@ -778,6 +778,7 @@ export class GraphQLServer {
                                         evaultPublicKey: this.evaultPublicKey,
                                         data: input.payload,
                                         schemaId: input.ontology,
+                                        operation: "create" as const,
                                     };
 
                                     // Fire-and-forget ingest to AaaS
@@ -949,6 +950,7 @@ export class GraphQLServer {
                                 data: result.bindingDocument,
                                 schemaId:
                                     BINDING_DOCUMENT_ONTOLOGY,
+                                operation: "create" as const,
                             };
                             this.notifyAwareness(
                                 webhookPayload,
@@ -1055,6 +1057,7 @@ export class GraphQLServer {
                                 data: result,
                                 schemaId:
                                     BINDING_DOCUMENT_ONTOLOGY,
+                                operation: "update" as const,
                             };
                             this.notifyAwareness(
                                 webhookPayload,
@@ -1239,6 +1242,7 @@ export class GraphQLServer {
                             evaultPublicKey: this.evaultPublicKey,
                             data: input.payload,
                             schemaId: input.ontology,
+                            operation: "create" as const,
                         };
 
                         this.notifyAwareness(
@@ -1492,6 +1496,7 @@ export class GraphQLServer {
                                 evaultPublicKey: this.evaultPublicKey,
                                 data: result.mergedPayload ?? input.payload,
                                 schemaId: input.ontology,
+                                operation: "update" as const,
                             };
 
                             // Fire-and-forget ingest to AaaS

--- a/infrastructure/evault-core/src/core/protocol/graphql-server.ts
+++ b/infrastructure/evault-core/src/core/protocol/graphql-server.ts
@@ -113,24 +113,44 @@ export class GraphQLServer {
             return;
         }
 
-        try {
-            await axios.post(
-                new URL(
-                    "/ingest",
-                    process.env.AWARENESS_SERVICE_URL,
-                ).toString(),
-                { ...webhookPayload, requestingPlatform },
-                {
-                    headers: {
-                        "Content-Type": "application/json",
-                        "x-ingest-secret":
-                            process.env.AWARENESS_INGEST_SECRET ?? "",
+        const ingestUrl = new URL(
+            "/ingest",
+            process.env.AWARENESS_SERVICE_URL,
+        ).toString();
+        const maxAttempts = 3;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            try {
+                const response = await axios.post(
+                    ingestUrl,
+                    { ...webhookPayload, requestingPlatform },
+                    {
+                        headers: {
+                            "Content-Type": "application/json",
+                            "x-ingest-secret":
+                                process.env.AWARENESS_INGEST_SECRET ?? "",
+                        },
+                        timeout: 5000,
                     },
-                    timeout: 5000,
-                },
-            );
-        } catch (error) {
-            console.log("Awareness ingest delivery failed");
+                );
+                console.log(
+                    `[webhook] AaaS accepted id=${webhookPayload?.id} status=${response.status} attempt=${attempt}`,
+                );
+                return;
+            } catch (error: any) {
+                const status = error?.response?.status ?? "no-response";
+                const code = error?.code ?? "unknown";
+                const message = error?.message ?? "unknown error";
+                console.error(
+                    `[webhook] AaaS ingest failed id=${webhookPayload?.id} status=${status} code=${code} attempt=${attempt}/${maxAttempts}: ${message}`,
+                );
+
+                if (attempt < maxAttempts) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, 250 * 2 ** (attempt - 1)),
+                    );
+                }
+            }
         }
     }
 
@@ -388,6 +408,7 @@ export class GraphQLServer {
                                 evaultPublicKey: this.evaultPublicKey,
                                 data: input.payload,
                                 schemaId: input.ontology,
+                                operation: "create" as const,
                             };
 
                             // Fire-and-forget ingest to AaaS
@@ -532,6 +553,7 @@ export class GraphQLServer {
                                 evaultPublicKey: this.evaultPublicKey,
                                 data: result.mergedPayload ?? input.payload,
                                 schemaId: input.ontology,
+                                operation: "update" as const,
                             };
 
                             // Fire-and-forget ingest to AaaS

--- a/services/awareness-service/README.md
+++ b/services/awareness-service/README.md
@@ -59,7 +59,9 @@ Service**.
 
 ## Backward compatibility
 
-On launch AaaS seeds a catch-all subscription for every platform currently in
-the registry, so existing webhook receivers keep getting every packet at
-`<platform>/api/webhook` with no change. Consumers can later narrow to specific
-ontologies / eVaults.
+On launch and periodically thereafter, AaaS reconciles a catch-all subscription
+for every platform currently in the registry, so existing and newly registered
+webhook receivers keep getting every packet at `<platform>/api/webhook` with no
+change. `AWARENESS_REGISTRY_SYNC_MS` controls the interval (default 60000; set
+to 0 to disable periodic reconciliation). Non-registry consumers can narrow
+their own subscriptions to specific ontologies / eVaults.

--- a/services/awareness-service/api/src/config.ts
+++ b/services/awareness-service/api/src/config.ts
@@ -11,6 +11,15 @@ function required(name: string): string {
     return value;
 }
 
+function timerInterval(name: string, fallback: number): number {
+    const raw = process.env[name];
+    if (raw === undefined || !/^\d+$/.test(raw)) return fallback;
+    const value = Number(raw);
+    return Number.isSafeInteger(value) && value <= 2_147_483_647
+        ? value
+        : fallback;
+}
+
 export const config = {
     /** Postgres connection string for the AaaS database. */
     databaseUrl: process.env.AWARENESS_DATABASE_URL ?? "",
@@ -33,10 +42,7 @@ export const config = {
         10,
     ),
     /** How often registry platforms are reconciled with catch-all subscriptions. */
-    registrySyncMs: parseInt(
-        process.env.AWARENESS_REGISTRY_SYNC_MS ?? "60000",
-        10,
-    ),
+    registrySyncMs: timerInterval("AWARENESS_REGISTRY_SYNC_MS", 60000),
     /** Public base URL of the AaaS API, used to build W3DS auth callbacks. */
     publicUrl: process.env.AWARENESS_PUBLIC_URL ?? "http://localhost:4100",
     dbCaCert: process.env.DB_CA_CERT,

--- a/services/awareness-service/api/src/config.ts
+++ b/services/awareness-service/api/src/config.ts
@@ -32,6 +32,11 @@ export const config = {
         process.env.AWARENESS_DELIVERY_POLL_MS ?? "2000",
         10,
     ),
+    /** How often registry platforms are reconciled with catch-all subscriptions. */
+    registrySyncMs: parseInt(
+        process.env.AWARENESS_REGISTRY_SYNC_MS ?? "60000",
+        10,
+    ),
     /** Public base URL of the AaaS API, used to build W3DS auth callbacks. */
     publicUrl: process.env.AWARENESS_PUBLIC_URL ?? "http://localhost:4100",
     dbCaCert: process.env.DB_CA_CERT,

--- a/services/awareness-service/api/src/controllers/AdminController.ts
+++ b/services/awareness-service/api/src/controllers/AdminController.ts
@@ -4,6 +4,8 @@ import { AccessApplication } from "../database/entities/AccessApplication";
 import { Consumer } from "../database/entities/Consumer";
 import { DeadLetter } from "../database/entities/DeadLetter";
 import { Delivery } from "../database/entities/Delivery";
+import { Packet } from "../database/entities/Packet";
+import { Subscription } from "../database/entities/Subscription";
 import { adminAuth } from "../middleware/portalAuth";
 
 /**
@@ -31,6 +33,34 @@ export function adminRouter(): Router {
             .orderBy("a.createdAt", "DESC")
             .getMany();
         res.json({ applications: apps });
+    });
+
+    // Inspect effective targets without exposing webhook signing secrets.
+    router.get("/api/admin/subscriptions", async (req, res) => {
+        const target =
+            typeof req.query.target === "string" ? req.query.target : null;
+        const qb = AppDataSource.getRepository(Subscription)
+            .createQueryBuilder("s")
+            .innerJoin(Consumer, "c", "c.id = s.consumerId")
+            .select([
+                's.id AS "subscriptionId"',
+                's.targetUrl AS "targetUrl"',
+                's.isCatchAll AS "isCatchAll"',
+                's.active AS "active"',
+                's.ontologyFilter AS "ontologyFilter"',
+                's.evaultFilter AS "evaultFilter"',
+                's.createdAt AS "createdAt"',
+                'c.id AS "consumerId"',
+                'c.ename AS "consumerEname"',
+                'c.status AS "consumerStatus"',
+                'c.webhookBaseUrl AS "webhookBaseUrl"',
+            ])
+            .orderBy("s.createdAt", "ASC");
+        if (target) {
+            qb.where("s.targetUrl ILIKE :target", { target: `%${target}%` });
+        }
+        const subscriptions = await qb.getRawMany();
+        res.json({ count: subscriptions.length, subscriptions });
     });
 
     router.post("/api/admin/applications/:id/approve", async (req, res) => {
@@ -98,6 +128,48 @@ export function adminRouter(): Router {
             take: 200,
         });
         res.json({ deadLetters });
+    });
+
+    // Definitive end-to-end trace for one awareness packet: every matched
+    // subscription, resolved target, owning consumer and delivery outcome.
+    router.get("/api/admin/packets/:id/deliveries", async (req, res) => {
+        const rows = await AppDataSource.getRepository(Delivery)
+            .createQueryBuilder("d")
+            .innerJoin(Subscription, "s", "s.id = d.subscriptionId")
+            .innerJoin(Consumer, "c", "c.id = s.consumerId")
+            .select([
+                'd.id AS "deliveryId"',
+                'd.packetId AS "packetId"',
+                'd.status AS "status"',
+                'd.attempts AS "attempts"',
+                'd.nextAttemptAt AS "nextAttemptAt"',
+                'd.deliveredAt AS "deliveredAt"',
+                'd.lastResponseStatus AS "lastResponseStatus"',
+                'd.lastError AS "lastError"',
+                's.id AS "subscriptionId"',
+                's.targetUrl AS "targetUrl"',
+                's.isCatchAll AS "isCatchAll"',
+                's.active AS "subscriptionActive"',
+                's.ontologyFilter AS "ontologyFilter"',
+                's.evaultFilter AS "evaultFilter"',
+                'c.id AS "consumerId"',
+                'c.ename AS "consumerEname"',
+                'c.status AS "consumerStatus"',
+            ])
+            .where("d.packetId = :packetId", { packetId: req.params.id })
+            .orderBy("d.createdAt", "ASC")
+            .getRawMany();
+
+        const packetExists = await AppDataSource.getRepository(Packet).exists({
+            where: { id: req.params.id },
+        });
+
+        res.json({
+            packetId: req.params.id,
+            packetExists,
+            deliveryCount: rows.length,
+            deliveries: rows,
+        });
     });
 
     // Replay re-queues the original delivery and resolves the dead letter.

--- a/services/awareness-service/api/src/controllers/AdminController.ts
+++ b/services/awareness-service/api/src/controllers/AdminController.ts
@@ -36,31 +36,37 @@ export function adminRouter(): Router {
     });
 
     // Inspect effective targets without exposing webhook signing secrets.
-    router.get("/api/admin/subscriptions", async (req, res) => {
-        const target =
-            typeof req.query.target === "string" ? req.query.target : null;
-        const qb = AppDataSource.getRepository(Subscription)
-            .createQueryBuilder("s")
-            .innerJoin(Consumer, "c", "c.id = s.consumerId")
-            .select([
-                's.id AS "subscriptionId"',
-                's.targetUrl AS "targetUrl"',
-                's.isCatchAll AS "isCatchAll"',
-                's.active AS "active"',
-                's.ontologyFilter AS "ontologyFilter"',
-                's.evaultFilter AS "evaultFilter"',
-                's.createdAt AS "createdAt"',
-                'c.id AS "consumerId"',
-                'c.ename AS "consumerEname"',
-                'c.status AS "consumerStatus"',
-                'c.webhookBaseUrl AS "webhookBaseUrl"',
-            ])
-            .orderBy("s.createdAt", "ASC");
-        if (target) {
-            qb.where("s.targetUrl ILIKE :target", { target: `%${target}%` });
+    router.get("/api/admin/subscriptions", async (req, res, next) => {
+        try {
+            const target =
+                typeof req.query.target === "string" ? req.query.target : null;
+            const qb = AppDataSource.getRepository(Subscription)
+                .createQueryBuilder("s")
+                .innerJoin(Consumer, "c", "c.id = s.consumerId")
+                .select([
+                    's.id AS "subscriptionId"',
+                    's.targetUrl AS "targetUrl"',
+                    's.isCatchAll AS "isCatchAll"',
+                    's.active AS "active"',
+                    's.ontologyFilter AS "ontologyFilter"',
+                    's.evaultFilter AS "evaultFilter"',
+                    's.createdAt AS "createdAt"',
+                    'c.id AS "consumerId"',
+                    'c.ename AS "consumerEname"',
+                    'c.status AS "consumerStatus"',
+                    'c.webhookBaseUrl AS "webhookBaseUrl"',
+                ])
+                .orderBy("s.createdAt", "ASC");
+            if (target) {
+                qb.where("s.targetUrl ILIKE :target", {
+                    target: `%${target}%`,
+                });
+            }
+            const subscriptions = await qb.getRawMany();
+            res.json({ count: subscriptions.length, subscriptions });
+        } catch (error) {
+            next(error);
         }
-        const subscriptions = await qb.getRawMany();
-        res.json({ count: subscriptions.length, subscriptions });
     });
 
     router.post("/api/admin/applications/:id/approve", async (req, res) => {
@@ -132,44 +138,50 @@ export function adminRouter(): Router {
 
     // Definitive end-to-end trace for one awareness packet: every matched
     // subscription, resolved target, owning consumer and delivery outcome.
-    router.get("/api/admin/packets/:id/deliveries", async (req, res) => {
-        const rows = await AppDataSource.getRepository(Delivery)
-            .createQueryBuilder("d")
-            .innerJoin(Subscription, "s", "s.id = d.subscriptionId")
-            .innerJoin(Consumer, "c", "c.id = s.consumerId")
-            .select([
-                'd.id AS "deliveryId"',
-                'd.packetId AS "packetId"',
-                'd.status AS "status"',
-                'd.attempts AS "attempts"',
-                'd.nextAttemptAt AS "nextAttemptAt"',
-                'd.deliveredAt AS "deliveredAt"',
-                'd.lastResponseStatus AS "lastResponseStatus"',
-                'd.lastError AS "lastError"',
-                's.id AS "subscriptionId"',
-                's.targetUrl AS "targetUrl"',
-                's.isCatchAll AS "isCatchAll"',
-                's.active AS "subscriptionActive"',
-                's.ontologyFilter AS "ontologyFilter"',
-                's.evaultFilter AS "evaultFilter"',
-                'c.id AS "consumerId"',
-                'c.ename AS "consumerEname"',
-                'c.status AS "consumerStatus"',
-            ])
-            .where("d.packetId = :packetId", { packetId: req.params.id })
-            .orderBy("d.createdAt", "ASC")
-            .getRawMany();
+    router.get("/api/admin/packets/:id/deliveries", async (req, res, next) => {
+        try {
+            const rows = await AppDataSource.getRepository(Delivery)
+                .createQueryBuilder("d")
+                .innerJoin(Subscription, "s", "s.id = d.subscriptionId")
+                .innerJoin(Consumer, "c", "c.id = s.consumerId")
+                .select([
+                    'd.id AS "deliveryId"',
+                    'd.packetId AS "packetId"',
+                    'd.status AS "status"',
+                    'd.attempts AS "attempts"',
+                    'd.nextAttemptAt AS "nextAttemptAt"',
+                    'd.deliveredAt AS "deliveredAt"',
+                    'd.lastResponseStatus AS "lastResponseStatus"',
+                    'd.lastError AS "lastError"',
+                    's.id AS "subscriptionId"',
+                    's.targetUrl AS "targetUrl"',
+                    's.isCatchAll AS "isCatchAll"',
+                    's.active AS "subscriptionActive"',
+                    's.ontologyFilter AS "ontologyFilter"',
+                    's.evaultFilter AS "evaultFilter"',
+                    'c.id AS "consumerId"',
+                    'c.ename AS "consumerEname"',
+                    'c.status AS "consumerStatus"',
+                ])
+                .where("d.packetId = :packetId", { packetId: req.params.id })
+                .orderBy("d.createdAt", "ASC")
+                .getRawMany();
 
-        const packetExists = await AppDataSource.getRepository(Packet).exists({
-            where: { id: req.params.id },
-        });
+            const packetExists = await AppDataSource.getRepository(
+                Packet,
+            ).exists({
+                where: { id: req.params.id },
+            });
 
-        res.json({
-            packetId: req.params.id,
-            packetExists,
-            deliveryCount: rows.length,
-            deliveries: rows,
-        });
+            res.json({
+                packetId: req.params.id,
+                packetExists,
+                deliveryCount: rows.length,
+                deliveries: rows,
+            });
+        } catch (error) {
+            next(error);
+        }
     });
 
     // Replay re-queues the original delivery and resolves the dead letter.

--- a/services/awareness-service/api/src/database/entities/Delivery.ts
+++ b/services/awareness-service/api/src/database/entities/Delivery.ts
@@ -41,6 +41,11 @@ export class Delivery {
     @Column({ type: "varchar" })
     contentHash!: string;
 
+    /** Immutable event snapshot; prevents later packet upserts changing this delivery. */
+    @Column({ type: "jsonb", nullable: true })
+    // `any` avoids TypeORM DeepPartial rejecting arbitrary JSON object values.
+    payload!: any;
+
     @Column({ type: "varchar", default: "pending" })
     status!: DeliveryStatus;
 

--- a/services/awareness-service/api/src/database/migrations/1780404367749-AddDeliveryPayload.ts
+++ b/services/awareness-service/api/src/database/migrations/1780404367749-AddDeliveryPayload.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/** Preserve the exact event body on each queued delivery. */
+export class AddDeliveryPayload1780404367749 implements MigrationInterface {
+    name = "AddDeliveryPayload1780404367749";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "deliveries" ADD "payload" jsonb`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "deliveries" DROP COLUMN "payload"`,
+        );
+    }
+}

--- a/services/awareness-service/api/src/index.ts
+++ b/services/awareness-service/api/src/index.ts
@@ -50,7 +50,9 @@ async function start(): Promise<void> {
 
     // Backward compat: keep every currently-registered platform receiving
     // everything, the same way evault-core's old fanout did.
-    await new SeedService().seedCatchAll();
+    const seedService = new SeedService();
+    await seedService.syncCatchAll();
+    seedService.start();
 
     const deliveryEngine = new DeliveryEngine();
     deliveryEngine.start();

--- a/services/awareness-service/api/src/services/DeliveryEngine.ts
+++ b/services/awareness-service/api/src/services/DeliveryEngine.ts
@@ -62,9 +62,31 @@ export class DeliveryEngine {
             // A slow or malicious subscription must not block unrelated
             // platforms in the same batch. Each request has its own timeout;
             // drain the claimed batch concurrently so failures are isolated.
-            await Promise.allSettled(
+            const results = await Promise.allSettled(
                 claimed.map((delivery) => this.attemptDelivery(delivery)),
             );
+            const rejected = results
+                .map((result, index) => ({ result, delivery: claimed[index] }))
+                .filter(
+                    (item): item is {
+                        result: PromiseRejectedResult;
+                        delivery: Delivery;
+                    } => item.result.status === "rejected",
+                );
+            for (const { result, delivery } of rejected) {
+                const message =
+                    result.reason instanceof Error
+                        ? result.reason.message
+                        : String(result.reason);
+                await AppDataSource.getRepository(Delivery).update(delivery.id, {
+                    status: "failed",
+                    lastError: message,
+                    nextAttemptAt: new Date(),
+                });
+                console.error(
+                    `[aaas] delivery ${delivery.id} task failed before completion: ${message}`,
+                );
+            }
             this.dbDown = false;
         } catch (err) {
             if (isDbUnavailable(err)) {
@@ -100,7 +122,13 @@ export class DeliveryEngine {
                 // already hit the cap) are terminal and never re-claimed.
                 `id IN (
                     SELECT id FROM deliveries
-                    WHERE status IN ('pending', 'failed')
+                    WHERE (
+                            status IN ('pending', 'failed')
+                            OR (
+                                status = 'delivering'
+                                AND "nextAttemptAt" <= now() - interval '1 minute'
+                            )
+                          )
                       AND attempts < :maxAttempts
                       AND "nextAttemptAt" <= now()
                     ORDER BY "nextAttemptAt"

--- a/services/awareness-service/api/src/services/DeliveryEngine.ts
+++ b/services/awareness-service/api/src/services/DeliveryEngine.ts
@@ -59,9 +59,12 @@ export class DeliveryEngine {
         this.running = true;
         try {
             const claimed = await this.claimBatch();
-            for (const delivery of claimed) {
-                await this.attemptDelivery(delivery);
-            }
+            // A slow or malicious subscription must not block unrelated
+            // platforms in the same batch. Each request has its own timeout;
+            // drain the claimed batch concurrently so failures are isolated.
+            await Promise.allSettled(
+                claimed.map((delivery) => this.attemptDelivery(delivery)),
+            );
             this.dbDown = false;
         } catch (err) {
             if (isDbUnavailable(err)) {
@@ -124,7 +127,7 @@ export class DeliveryEngine {
             where: { id: delivery.packetId },
         });
 
-        if (!subscription || !packet) {
+        if (!subscription || (!packet && !delivery.payload)) {
             await this.fail(
                 delivery,
                 subscription,
@@ -134,12 +137,16 @@ export class DeliveryEngine {
             return;
         }
 
-        const payload: AwarenessPayload = {
-            id: packet.id,
-            w3id: packet.w3id,
-            evaultPublicKey: packet.evaultPublicKey,
-            data: packet.data,
-            schemaId: packet.ontology,
+        // New rows carry an immutable snapshot so rapid updates to the same
+        // envelope cannot overwrite an older event before it is delivered.
+        // Fall back to Packet for deliveries created before this column existed.
+        const payload: AwarenessPayload = delivery.payload ?? {
+            id: packet!.id,
+            w3id: packet!.w3id,
+            evaultPublicKey: packet!.evaultPublicKey,
+            data: packet!.data,
+            schemaId: packet!.ontology,
+            operation: packet!.operation,
         };
 
         const headers: Record<string, string> = {

--- a/services/awareness-service/api/src/services/IngestService.ts
+++ b/services/awareness-service/api/src/services/IngestService.ts
@@ -60,7 +60,17 @@ export class IngestService {
         // Dedupe deliveries by payload content rather than packet id alone:
         // re-ingesting an updated envelope (new hash) must queue a new delivery,
         // while a retried POST of the same payload (same hash) must not.
-        const hash = contentHash(payload.data ?? null);
+        // The operation is part of the event identity. A delete can carry the
+        // same (often null) data as another event and must still be delivered.
+        const deliveryPayload: AwarenessPayload = {
+            id: payload.id,
+            w3id: payload.w3id ?? null,
+            evaultPublicKey: payload.evaultPublicKey ?? null,
+            data: payload.data ?? null,
+            schemaId: payload.schemaId,
+            operation: payload.operation ?? "create",
+        };
+        const hash = contentHash(deliveryPayload);
 
         const deliveryRepo = AppDataSource.getRepository(Delivery);
         const rows = subscriptions.map((sub) =>
@@ -68,6 +78,7 @@ export class IngestService {
                 subscriptionId: sub.id,
                 packetId: packet.id,
                 contentHash: hash,
+                payload: deliveryPayload,
                 status: "pending",
                 attempts: 0,
                 nextAttemptAt: new Date(),

--- a/services/awareness-service/api/src/services/SeedService.ts
+++ b/services/awareness-service/api/src/services/SeedService.ts
@@ -20,7 +20,9 @@ export class SeedService {
     start(): void {
         if (!config.registryUrl || config.registrySyncMs <= 0) return;
         this.timer = setInterval(() => {
-            void this.syncCatchAll();
+            void this.syncCatchAll().catch((err) => {
+                console.error("[seed] registry reconciliation failed:", err);
+            });
         }, config.registrySyncMs);
         console.log(
             `[seed] registry reconciliation started (poll ${config.registrySyncMs}ms)`,
@@ -63,6 +65,7 @@ export class SeedService {
         const consumerRepo = AppDataSource.getRepository(Consumer);
         const subRepo = AppDataSource.getRepository(Subscription);
         let seeded = 0;
+        const currentTargets = new Map<string, string>();
 
         for (const platformUrl of platforms) {
             let host: string;
@@ -76,6 +79,7 @@ export class SeedService {
             }
 
             const ename = `catchall:${host}`;
+            currentTargets.set(ename, targetUrl);
             let consumer = await consumerRepo.findOne({ where: { ename } });
             if (!consumer) {
                 consumer = consumerRepo.create({
@@ -124,6 +128,30 @@ export class SeedService {
                 existing.ontologyFilter = [];
                 existing.evaultFilter = [];
                 await subRepo.save(existing);
+                seeded += 1;
+            }
+        }
+
+        const managedSubscriptions = await subRepo
+            .createQueryBuilder("s")
+            .innerJoin(Consumer, "c", "c.id = s.consumerId")
+            .addSelect('c.ename', "consumerEname")
+            .where("s.isCatchAll = true")
+            .andWhere("s.active = true")
+            .andWhere("c.ename LIKE :prefix", { prefix: "catchall:%" })
+            .getRawAndEntities();
+
+        for (
+            let index = 0;
+            index < managedSubscriptions.entities.length;
+            index += 1
+        ) {
+            const subscription = managedSubscriptions.entities[index];
+            const ename = managedSubscriptions.raw[index]
+                .consumerEname as string;
+            if (currentTargets.get(ename) !== subscription.targetUrl) {
+                subscription.active = false;
+                await subRepo.save(subscription);
                 seeded += 1;
             }
         }

--- a/services/awareness-service/api/src/services/SeedService.ts
+++ b/services/awareness-service/api/src/services/SeedService.ts
@@ -6,13 +6,42 @@ import { config } from "../config";
 
 /**
  * Backward-compat seeding. Before AaaS, evault-core fanned out every webhook to
- * every registered platform. To preserve that behaviour, on launch we ensure
- * each platform currently in the registry has an approved consumer and a
- * catch-all subscription (empty filters) pointing at `<platform>/api/webhook`.
+ * every registered platform. To preserve that behaviour, on launch and at a
+ * configured interval we ensure each platform currently in the registry has
+ * an approved consumer and an active catch-all subscription (empty filters)
+ * pointing at `<platform>/api/webhook`.
  *
- * Idempotent: existing catch-all subscriptions are left untouched.
+ * Idempotent: valid existing catch-all subscriptions are reused.
  */
 export class SeedService {
+    private timer?: NodeJS.Timeout;
+    private syncing = false;
+
+    start(): void {
+        if (!config.registryUrl || config.registrySyncMs <= 0) return;
+        this.timer = setInterval(() => {
+            void this.syncCatchAll();
+        }, config.registrySyncMs);
+        console.log(
+            `[seed] registry reconciliation started (poll ${config.registrySyncMs}ms)`,
+        );
+    }
+
+    stop(): void {
+        if (this.timer) clearInterval(this.timer);
+    }
+
+    /** Prevent overlapping registry requests when one reconciliation is slow. */
+    async syncCatchAll(): Promise<{ seeded: number; total: number }> {
+        if (this.syncing) return { seeded: 0, total: 0 };
+        this.syncing = true;
+        try {
+            return await this.seedCatchAll();
+        } finally {
+            this.syncing = false;
+        }
+    }
+
     async seedCatchAll(): Promise<{ seeded: number; total: number }> {
         if (!config.registryUrl) {
             console.warn("[seed] PUBLIC_REGISTRY_URL not set, skipping");
@@ -57,6 +86,14 @@ export class SeedService {
                     approvedAt: new Date(),
                 });
                 await consumerRepo.save(consumer);
+            } else {
+                // Registry-level consumers are managed by this compatibility
+                // sync. Keep them deliverable even if an earlier subscription
+                // or consumer record was disabled.
+                consumer.status = "approved";
+                consumer.webhookBaseUrl = platformUrl;
+                consumer.approvedAt ??= new Date();
+                await consumerRepo.save(consumer);
             }
 
             const existing = await subRepo.findOne({
@@ -78,11 +115,21 @@ export class SeedService {
                     }),
                 );
                 seeded += 1;
+            } else if (
+                !existing.active ||
+                existing.ontologyFilter.length > 0 ||
+                existing.evaultFilter.length > 0
+            ) {
+                existing.active = true;
+                existing.ontologyFilter = [];
+                existing.evaultFilter = [];
+                await subRepo.save(existing);
+                seeded += 1;
             }
         }
 
         console.log(
-            `[seed] catch-all seeding done: ${seeded} new of ${platforms.length} platforms`,
+            `[seed] catch-all reconciliation done: ${seeded} changed of ${platforms.length} platforms`,
         );
         return { seeded, total: platforms.length };
     }


### PR DESCRIPTION
# Description of change

Improves awareness webhook reliability and diagnostics.

- Keeps registry catch-all subscriptions active and synchronized
- Retries eVault ingestion failures with useful status logging
- Preserves the exact payload and operation for every queued event
- Delivers webhook batches concurrently so one slow target cannot block others
- Adds admin endpoints for inspecting subscriptions and packet delivery outcomes

## Issue Number

N/A

## Type of change

- Fix

## How the change has been tested

- TypeScript compilation for `evault-core`
- TypeScript compilation for `awareness-service-api`
- `git diff --check`

## Change checklist

- [ ] I have ensured that the CI Checks pass locally
- [x] I have removed any unnecessary logic
- [x] My code is well documented
- [ ] I have signed my commits
- [x] My code follows the pattern of the application
- [x] I have self reviewed my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated tools to inspect subscriptions, consumer targets, and packet delivery results.
  * Added delivery history payload snapshots for improved troubleshooting.
  * Registry webhook subscriptions now reconcile at startup and on a configurable schedule.
  * Added `AWARENESS_REGISTRY_SYNC_MS` configuration; set to `0` to disable periodic synchronization.

* **Bug Fixes**
  * Improved webhook reliability with retries and exponential backoff.
  * Prevented individual delivery failures from blocking other deliveries.
  * Improved event deduplication and support for deliveries whose packet records are unavailable.

* **Documentation**
  * Updated setup and compatibility guidance for registry synchronization and subscription filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->